### PR TITLE
fix: display formatting issue with multiple currency symbols in markdo…

### DIFF
--- a/src/markdown-parser.ts
+++ b/src/markdown-parser.ts
@@ -57,11 +57,13 @@ export class MarkdownParser {
   }
 
   markdownToAst(content: string, loading: boolean = false): SyntaxTree {
+    const singleDollarTextMath = this.options.mdastOptions?.singleDollarTextMath ?? false
+
     const data = fromMarkdown(content, {
       extensions: [
         gfm(),
         math({
-          singleDollarTextMath: false,
+          singleDollarTextMath,
         }),
         frontmatter(),
         cjkFriendlyExtension(),

--- a/src/types/context.ts
+++ b/src/types/context.ts
@@ -35,6 +35,7 @@ export interface MarkdownParserOptions {
 }
 
 export interface MdastOptions {
+  singleDollarTextMath?: boolean
   from?: FromMarkdownExtension[]
   to?: ToMarkdownExtension[]
   micromark?: MicromarkExtension[]


### PR DESCRIPTION
…wn input.

Default to the setting that fixes this bug before exposing this via API

fixes #12 