### PR TITLE
Add margin-bottom to non-last paragraph elements

### DIFF
--- a/src/components/renderers/paragraph.vue
+++ b/src/components/renderers/paragraph.vue
@@ -13,11 +13,8 @@ const props = withDefaults(defineProps<ParagraphNodeRendererProps>(), {})
 
 <style>
 :is(.stream-markdown, .stream-markdown-overlay) [data-stream-markdown='paragraph'] {
+  margin-bottom: 1rem;
   vertical-align: middle;
   transition: height var(--default-transition-duration) ease;
-}
-
-:is(.stream-markdown, .stream-markdown-overlay) [data-stream-markdown='paragraph']:not(:last-child) {
-  margin-bottom: 1rem;
 }
 </style>

--- a/src/style.css
+++ b/src/style.css
@@ -32,6 +32,14 @@
   padding: 0;
 }
 
+:is(.stream-markdown, .stream-markdown-overlay) > *:first-child {
+  margin-top: 0 !important;
+}
+
+:is(.stream-markdown, .stream-markdown-overlay) > *:last-child {
+  margin-bottom: 0 !important;
+}
+
 :is(.stream-markdown, .stream-markdown-overlay) ::-webkit-scrollbar {
   width: 6px;
   height: 6px;


### PR DESCRIPTION
Ensure that we only add a `margin-bottom` to non-last paragraph elements.