### PR TITLE
feat: support image referrer policy

### DIFF
--- a/docs/config/display-options.md
+++ b/docs/config/display-options.md
@@ -257,6 +257,7 @@ Configuration for image display options, including fallback images, captions, an
 interface ImageOptions {
   fallback?: string
   caption?: boolean
+  referrerPolicy?: ReferrerPolicy
   errorComponent?: Component
 }
 ```
@@ -286,6 +287,28 @@ Fallback image URL to display when an image fails to load. If provided, the fall
 **With fallback:**
 
 <StreamMarkdown :content="imageWithFallback" :image-options="{ fallback: 'https://placehold.co/600x400' }" />
+
+### referrerPolicy
+
+- **Type:** `ReferrerPolicy | undefined`
+- **Default:** `undefined` (browser default)
+
+Controls the referrer policy used by rendered image requests. This is useful when external image hosts should not receive the current page URL as the referrer.
+
+```vue
+<script setup lang="ts">
+import type { ImageOptions } from 'vue-stream-markdown'
+import { Markdown } from 'vue-stream-markdown'
+
+const imageOptions: ImageOptions = {
+  referrerPolicy: 'no-referrer',
+}
+</script>
+
+<template>
+  <Markdown :content="content" :image-options="imageOptions" />
+</template>
+```
 
 ### errorComponent
 
@@ -322,6 +345,7 @@ import { Markdown } from 'vue-stream-markdown'
 const imageOptions: ImageOptions = {
   fallback: 'https://placehold.co/600x400',
   caption: true,
+  referrerPolicy: 'no-referrer',
 }
 </script>
 

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -538,6 +538,12 @@ Fallback image URL when image fails to load.
 
 Whether to display image captions.
 
+#### referrerPolicy
+
+- **Type:** `ReferrerPolicy`
+
+Referrer policy to apply to rendered image requests, including image previews. For example, use `'no-referrer'` to prevent external image hosts from receiving the current page URL.
+
 #### errorComponent
 
 - **Type:** `Component`

--- a/packages/core/src/types/options.ts
+++ b/packages/core/src/types/options.ts
@@ -48,6 +48,7 @@ export interface KatexOptions<TComponent = unknown, TConfig = unknown> {
 export interface ImageOptions<TComponent = unknown> {
   fallback?: string
   caption?: boolean
+  referrerPolicy?: ReferrerPolicy
   errorComponent?: TComponent
 }
 

--- a/packages/core/src/types/ui.ts
+++ b/packages/core/src/types/ui.ts
@@ -64,6 +64,7 @@ export interface UIImageProps<
   alt?: string
   title?: string
   preview?: boolean
+  referrerPolicy?: ReferrerPolicy
   margin?: number
   controls?: TControls
   transformHardenUrl?: (url: string) => string | null

--- a/packages/vue/src/components/image.vue
+++ b/packages/vue/src/components/image.vue
@@ -174,6 +174,7 @@ watch(open, (data) => {
     ref="elementRef"
     data-stream-markdown="image"
     class="rounded-lg h-auto max-w-full block cursor-pointer object-contain"
+    :referrerpolicy="referrerPolicy"
     :src="src"
     :alt="alt"
     :title="title"
@@ -219,6 +220,7 @@ watch(open, (data) => {
 
       <img
         ref="_zoomElementRef"
+        :referrerpolicy="referrerPolicy"
         :src="imageSrc"
         :alt="alt"
         :title="title"

--- a/packages/vue/src/components/renderers/image.vue
+++ b/packages/vue/src/components/renderers/image.vue
@@ -146,6 +146,7 @@ function handleMouseLeave() {
         :alt="alt"
         :title="title"
         :preview="!fallbackAttempted && enablePreview"
+        :referrer-policy="imageOptions?.referrerPolicy"
         :controls="controls"
         :transform-harden-url="transformHardenUrl"
         :node-props="props"

--- a/test/vue/image.test.ts
+++ b/test/vue/image.test.ts
@@ -1,0 +1,112 @@
+// @vitest-environment happy-dom
+import type { ImageNode, MarkdownAstParser, NodeRenderers } from 'vue-stream-markdown'
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import { defineComponent, h } from 'vue'
+import Image from '../../packages/vue/src/components/image.vue'
+import ImageRenderer from '../../packages/vue/src/components/renderers/image.vue'
+import { useContext } from '../../packages/vue/src/composables'
+
+const PassthroughModal = defineComponent({
+  setup(_, { slots }) {
+    return () => h('div', { 'data-test': 'modal' }, slots.default?.())
+  },
+})
+
+const PassthroughZoomContainer = defineComponent({
+  setup(_, { slots }) {
+    return () => h('div', { 'data-test': 'zoom-container' }, slots.default?.())
+  },
+})
+
+describe('image renderer', () => {
+  it('passes imageOptions.referrerPolicy to custom image components', () => {
+    const CustomImage = defineComponent({
+      props: {
+        referrerPolicy: String,
+      },
+      setup(props) {
+        return () => h('img', {
+          'data-test': 'custom-image',
+          'referrerpolicy': props.referrerPolicy,
+        })
+      },
+    })
+
+    const WrappedImageRenderer = defineComponent({
+      setup() {
+        const { provideContext } = useContext()
+
+        provideContext({
+          controls: false,
+          imageOptions: {
+            referrerPolicy: 'no-referrer',
+          },
+          uiComponents: {
+            Image: CustomImage,
+          } as never,
+        })
+
+        return () => h(ImageRenderer, {
+          markdownParser: {} as MarkdownAstParser,
+          nodeRenderers: {} as NodeRenderers,
+          node: {
+            type: 'image',
+            url: 'https://example.com/image.png',
+            alt: 'Example',
+          } as ImageNode,
+          nodeKey: 'stream-markdown-block-0-image-0',
+          deep: 1,
+        })
+      },
+    })
+
+    const wrapper = mount(WrappedImageRenderer)
+
+    expect(wrapper.find('[data-test="custom-image"]').attributes('referrerpolicy')).toBe('no-referrer')
+  })
+})
+
+describe('image component', () => {
+  it('applies referrerPolicy to inline and preview images', () => {
+    const WrappedImage = defineComponent({
+      setup() {
+        const { provideContext } = useContext()
+
+        provideContext({
+          uiComponents: {
+            Modal: PassthroughModal,
+            ZoomContainer: PassthroughZoomContainer,
+          } as never,
+        })
+
+        return () => h(Image, {
+          src: 'https://example.com/image.png',
+          alt: 'Example',
+          title: 'Example image',
+          controls: false,
+          referrerPolicy: 'no-referrer',
+          nodeProps: {
+            markdownParser: {} as MarkdownAstParser,
+            nodeRenderers: {} as NodeRenderers,
+            node: {
+              type: 'image',
+              url: 'https://example.com/image.png',
+            } as ImageNode,
+            nodeKey: 'stream-markdown-block-0-image-0',
+            deep: 1,
+          },
+        })
+      },
+    })
+
+    const wrapper = mount(WrappedImage)
+    const images = wrapper.findAll('img')
+
+    expect(images).toHaveLength(2)
+    expect(images.map(image => image.attributes('referrerpolicy'))).toEqual([
+      'no-referrer',
+      'no-referrer',
+    ])
+  })
+})


### PR DESCRIPTION
## Summary

  - add `imageOptions.referrerPolicy` to configure rendered image referrer policy
  - apply the referrer policy to both inline images and preview images
  - expose `referrerPolicy` through `UIImageProps` for custom image components
  - document the new image option and add Vue renderer tests
## Test

  - `pnpm test test/vue/image.test.ts`
  - `pnpm test`
  - `pnpm exec tsc --noEmit`
  - `pnpm exec vue-tsc --noEmit`