### PR TITLE
feat!: support custom shiki highlighter engine

### DIFF
--- a/docs/config/external-options.md
+++ b/docs/config/external-options.md
@@ -18,6 +18,7 @@ interface ShikiOptions {
   theme?: [BuiltinTheme, BuiltinTheme]
   langs?: BundledLanguage[]
   langAlias?: Record<string, string>
+  engine?: RegexEngine | Promise<RegexEngine>
   codeToTokenOptions?: CodeToTokensOptions<BundledLanguage, BundledTheme>
 }
 ```
@@ -103,6 +104,13 @@ const shikiOptions: ShikiOptions = {
   <Markdown :content="content" :shiki-options="shikiOptions" />
 </template>
 ```
+
+### engine
+
+- **Type:** `RegexEngine | Promise<RegexEngine>`
+- **Default:** `createJavaScriptRegexEngine({ forgiving: true })`
+
+Custom Shiki regex engine. The default JavaScript engine avoids WebAssembly CSP restrictions.
 
 ### codeToTokenOptions
 

--- a/packages/core/src/types/options.ts
+++ b/packages/core/src/types/options.ts
@@ -19,10 +19,12 @@ export interface ShikiOptions<
   TTheme = string,
   TLanguage = string,
   TCodeToTokenOptions = unknown,
+  TEngine = unknown,
 > {
   theme?: [TTheme, TTheme]
   langs?: TLanguage[]
   langAlias?: Record<string, string>
+  engine?: TEngine
   codeToTokenOptions?: TCodeToTokenOptions
 }
 

--- a/packages/extensions/code/src/runtime.ts
+++ b/packages/extensions/code/src/runtime.ts
@@ -5,6 +5,7 @@ import type {
   Highlighter,
   TokensResult,
 } from 'shiki'
+import { createJavaScriptRegexEngine } from 'shiki/engine/javascript'
 import type { CodeRuntimeOptions, ShikiRuntime } from './types'
 import { resolveGetter } from '@stream-markdown/core'
 import { createShikiCdnLoader } from './cdn'
@@ -126,10 +127,12 @@ export function createShikiRuntime(options: CodeRuntimeOptions = {}): ShikiRunti
       if (!createHighlighterPromise) {
         createHighlighterPromise = (async () => {
           const { createHighlighter } = await getShiki()
+          const jsEngine = createJavaScriptRegexEngine({ forgiving: true })
           return createHighlighter({
             themes: await getThemes(),
             langs: getLangs(),
             langAlias: getLangAlias(),
+            engine: jsEngine,
           })
         })()
       }

--- a/packages/extensions/code/src/runtime.ts
+++ b/packages/extensions/code/src/runtime.ts
@@ -3,16 +3,29 @@ import type {
   BundledLanguage,
   BundledTheme,
   Highlighter,
+  RegexEngine,
   TokensResult,
 } from 'shiki'
-import { createJavaScriptRegexEngine } from 'shiki/engine/javascript'
 import type { CodeRuntimeOptions, ShikiRuntime } from './types'
 import { resolveGetter } from '@stream-markdown/core'
+import { createJavaScriptRegexEngine } from 'shiki'
 import { createShikiCdnLoader } from './cdn'
 import { DEFAULT_SHIKI_DARK_THEME, DEFAULT_SHIKI_LIGHT_THEME, LANGUAGE_ALIAS } from './constants'
 
 let highlighter: Highlighter | null = null
 let createHighlighterPromise: Promise<Highlighter> | null = null
+let defaultShikiEngine: RegexEngine | null = null
+
+function createDefaultShikiEngine(): RegexEngine {
+  defaultShikiEngine ??= createJavaScriptRegexEngine({ forgiving: true })
+  return defaultShikiEngine
+}
+
+export async function resolveShikiEngine(
+  engine: CodeRuntimeOptions['engine'],
+): Promise<RegexEngine> {
+  return await (resolveGetter(engine) ?? createDefaultShikiEngine())
+}
 
 function normalizeShikiModule(module: typeof import('shiki')): typeof import('shiki') {
   let defaultExport: typeof import('shiki') | undefined
@@ -127,12 +140,12 @@ export function createShikiRuntime(options: CodeRuntimeOptions = {}): ShikiRunti
       if (!createHighlighterPromise) {
         createHighlighterPromise = (async () => {
           const { createHighlighter } = await getShiki()
-          const jsEngine = createJavaScriptRegexEngine({ forgiving: true })
+          const engine = await resolveShikiEngine(options.engine)
           return createHighlighter({
             themes: await getThemes(),
             langs: getLangs(),
             langAlias: getLangAlias(),
-            engine: jsEngine,
+            engine,
           })
         })()
       }

--- a/packages/extensions/code/src/types.ts
+++ b/packages/extensions/code/src/types.ts
@@ -1,4 +1,4 @@
-import type { MaybeGetter, SharedCdnOptions } from '@stream-markdown/core'
+import type { MaybeGetter, MaybePromise, SharedCdnOptions } from '@stream-markdown/core'
 import type {
   BuiltinLanguage,
   BuiltinTheme,
@@ -6,10 +6,12 @@ import type {
   BundledTheme,
   CodeToTokensOptions,
   Highlighter,
+  RegexEngine,
   TokensResult,
 } from 'shiki'
 
 export type { MaybeGetter }
+export type ShikiEngine = MaybePromise<RegexEngine>
 
 export interface CodeRuntimeOptions {
   lang?: MaybeGetter<string | undefined>
@@ -18,6 +20,7 @@ export interface CodeRuntimeOptions {
   theme?: MaybeGetter<[BuiltinTheme, BuiltinTheme] | undefined>
   langs?: MaybeGetter<BundledLanguage[] | undefined>
   langAlias?: MaybeGetter<Record<string, string> | undefined>
+  engine?: MaybeGetter<ShikiEngine | undefined>
   codeToTokenOptions?: MaybeGetter<CodeToTokensOptions<BundledLanguage, BundledTheme> | undefined>
 }
 

--- a/packages/vue/src/composables/use-mermaid.ts
+++ b/packages/vue/src/composables/use-mermaid.ts
@@ -28,6 +28,7 @@ export function useMermaid(options?: UseMermaidOptions) {
         theme: () => shikiTheme,
         langs: () => toValue(options?.shikiOptions)?.langs ?? [],
         langAlias: () => toValue(options?.shikiOptions)?.langAlias ?? {},
+        engine: () => toValue(options?.shikiOptions)?.engine,
         codeToTokenOptions: () => toValue(options?.shikiOptions)?.codeToTokenOptions,
       })
       const [{ fromShikiTheme }, highlighter] = await Promise.all([

--- a/packages/vue/src/composables/use-shiki.ts
+++ b/packages/vue/src/composables/use-shiki.ts
@@ -36,6 +36,7 @@ export function useShiki(options?: UseShikiOptions) {
       ...LANGUAGE_ALIAS,
       ...(toValue(options?.shikiOptions)?.langAlias ?? {}),
     }),
+    engine: () => toValue(options?.shikiOptions)?.engine,
     codeToTokenOptions: () => toValue(options?.shikiOptions)?.codeToTokenOptions,
   })
 

--- a/packages/vue/src/types/shared.ts
+++ b/packages/vue/src/types/shared.ts
@@ -23,7 +23,7 @@ import type {
 import type { RenderOptions as BeautifulMermaidConfig, ThemeName } from 'beautiful-mermaid'
 import type { KatexOptions as KatexConfig } from 'katex'
 import type { MermaidConfig } from 'mermaid'
-import type { BuiltinTheme, BundledLanguage, BundledTheme, CodeToTokensOptions } from 'shiki'
+import type { BuiltinTheme, BundledLanguage, BundledTheme, CodeToTokensOptions, RegexEngine } from 'shiki'
 import type { Component } from 'vue'
 import type { ICONS } from '../components/icons'
 import type {
@@ -76,7 +76,8 @@ export type PreviewerConfig = CorePreviewerConfig<Component>
 export type ShikiOptions = CoreShikiOptions<
   BuiltinTheme,
   BundledLanguage,
-  CodeToTokensOptions<BundledLanguage, BundledTheme>
+  CodeToTokensOptions<BundledLanguage, BundledTheme>,
+  RegexEngine | Promise<RegexEngine>
 >
 
 export type MermaidOptions = CoreMermaidOptions<

--- a/test/code-runtime.test.ts
+++ b/test/code-runtime.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  defaultEngine: { name: 'default-engine' },
+  createJavaScriptRegexEngine: vi.fn(),
+}))
+
+vi.mock('shiki', () => ({
+  createJavaScriptRegexEngine: mocks.createJavaScriptRegexEngine,
+}))
+
+describe('resolveShikiEngine', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.createJavaScriptRegexEngine.mockReturnValue(mocks.defaultEngine)
+  })
+
+  it('uses the JavaScript regex engine by default', async () => {
+    const { resolveShikiEngine } = await import('@stream-markdown/code')
+
+    await expect(resolveShikiEngine(undefined)).resolves.toBe(mocks.defaultEngine)
+    expect(mocks.createJavaScriptRegexEngine).toHaveBeenCalledWith({ forgiving: true })
+  })
+
+  it('uses a custom engine when provided', async () => {
+    const { resolveShikiEngine } = await import('@stream-markdown/code')
+    const customEngine = { name: 'custom-engine' } as never
+
+    await expect(resolveShikiEngine(customEngine)).resolves.toBe(customEngine)
+    expect(mocks.createJavaScriptRegexEngine).not.toHaveBeenCalled()
+  })
+
+  it('resolves an async custom engine', async () => {
+    const { resolveShikiEngine } = await import('@stream-markdown/code')
+    const customEngine = { name: 'async-engine' } as never
+
+    await expect(resolveShikiEngine(Promise.resolve(customEngine))).resolves.toBe(customEngine)
+    expect(mocks.createJavaScriptRegexEngine).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Close #49 by using javaScript regExp engine by default