### PR TITLE
feat!: support custom html previewer sandbox attributes

### DIFF
--- a/docs/config/previewers.md
+++ b/docs/config/previewers.md
@@ -99,6 +99,9 @@ type PreviewerConfig
     | {
       placement?: PreviewSegmentedPlacement
       progressive?: Record<string, boolean>
+      html?: {
+        sandbox?: string
+      }
       components?: {
         mermaid?: boolean | Component
         html?: boolean | Component
@@ -110,6 +113,7 @@ The `PreviewerConfig` is an object that can contain:
 
 - **placement**: Optional placement configuration for preview components (see [placement](#placement) section below)
 - **progressive**: Optional configuration for progressive rendering (see [progressive](#progressive) section below)
+- **html**: Optional configuration for the built-in HTML previewer, including the iframe sandbox permissions
 - **components**: Optional object containing language-specific previewer configurations
   - For `html` and `mermaid`: `boolean` (to enable/disable default previewer) or `Component` (custom previewer)
   - For all other languages: `Component` only (no built-in previewers available)
@@ -168,18 +172,17 @@ const previewers: PreviewerConfig = {
 
 ## html
 
-- **Type:** `boolean | Component | undefined` (within `components` object)
-- **Default:** `true` (HTML previewer enabled when `previewers` is `true`)
+- **Sandbox type:** `string`
+- **Default sandbox:** `'allow-scripts'`
+- **Component type:** `boolean | Component | undefined` (within `components.html`)
 
-Controls the HTML previewer for HTML code blocks. This option must be specified within the `components` object. When set to `true`, the default HTML previewer is used, which renders HTML content in a sandboxed iframe. When set to `false`, the previewer is disabled and only the code is shown. When set to a Vue component, that component is used as the custom previewer.
-
-The default HTML previewer renders HTML content in a sandboxed iframe with `allow-scripts` and `allow-same-origin` permissions, allowing the HTML to execute JavaScript while maintaining security isolation. The iframe automatically adjusts its height based on the content.
+HTML code blocks use the built-in iframe previewer by default. Configure `html.sandbox` to change the iframe `sandbox` attribute, or use `components.html` to disable or replace the previewer.
 
 **HTML code block with preview:**
 
 <StreamMarkdown :content="htmlExample" />
 
-**Disable HTML previewer:**
+**Configure HTML previewer:**
 
 ```vue
 <script setup lang="ts">
@@ -187,8 +190,11 @@ import type { PreviewerConfig } from 'vue-stream-markdown'
 import { Markdown } from 'vue-stream-markdown'
 
 const previewers: PreviewerConfig = {
+  html: {
+    sandbox: 'allow-scripts allow-same-origin allow-forms',
+  },
   components: {
-    html: false,
+    html: true, // Set to false to disable the HTML previewer
   },
 }
 </script>

--- a/packages/core/src/core/html.ts
+++ b/packages/core/src/core/html.ts
@@ -1,7 +1,18 @@
 import type { CodeNode } from '@markmend/ast'
+import type { PreviewerConfig } from '../types'
+
+export const DEFAULT_HTML_PREVIEW_SANDBOX = 'allow-scripts'
 
 export function createHtmlPreviewModel(node: CodeNode) {
   return {
     code: node.value.trim(),
   }
+}
+
+export function resolveHtmlPreviewSandbox<TComponent = unknown>(
+  previewers: PreviewerConfig<TComponent> | undefined,
+): string {
+  if (typeof previewers === 'object' && typeof previewers.html?.sandbox === 'string')
+    return previewers.html.sandbox
+  return DEFAULT_HTML_PREVIEW_SANDBOX
 }

--- a/packages/core/src/types/options.ts
+++ b/packages/core/src/types/options.ts
@@ -4,11 +4,16 @@ export interface PreloadConfig<TBuiltinNodeRenderer extends string = string> {
 
 export type PreviewSegmentedPlacement = 'left' | 'center' | 'right' | 'auto'
 
+export interface HtmlPreviewerOptions {
+  sandbox?: string
+}
+
 export type PreviewerConfig<TComponent = unknown>
   = | boolean
     | {
       placement?: PreviewSegmentedPlacement
       progressive?: Record<string, boolean>
+      html?: HtmlPreviewerOptions
       components?: {
         mermaid?: boolean | TComponent
         html?: boolean | TComponent

--- a/packages/vue/src/components/previewers/html.vue
+++ b/packages/vue/src/components/previewers/html.vue
@@ -1,14 +1,17 @@
 <script setup lang="ts">
 import type { CodeNodeRendererProps } from '../../types'
-import { createHtmlPreviewModel, getIframeBodyHeight } from '@stream-markdown/core'
+import { createHtmlPreviewModel, getIframeBodyHeight, resolveHtmlPreviewSandbox } from '@stream-markdown/core'
 import { computed, ref } from 'vue'
+import { useContext } from '../../composables'
 
 const props = withDefaults(defineProps<CodeNodeRendererProps>(), {})
+const { previewers } = useContext()
 
 const iframeRef = ref<HTMLIFrameElement>()
 const height = ref<number>(0)
 const model = computed(() => createHtmlPreviewModel(props.node))
 const code = computed(() => model.value.code)
+const sandbox = computed(() => resolveHtmlPreviewSandbox(previewers.value))
 
 function updateHeight() {
   height.value = getIframeBodyHeight(iframeRef.value)
@@ -25,7 +28,7 @@ function updateHeight() {
       data-stream-markdown="html-previewer"
       class="size-full"
       :srcdoc="code"
-      sandbox="allow-scripts"
+      :sandbox="sandbox"
       :frameborder="0"
       @load="updateHeight"
     />

--- a/packages/vue/src/components/previewers/html.vue
+++ b/packages/vue/src/components/previewers/html.vue
@@ -25,7 +25,7 @@ function updateHeight() {
       data-stream-markdown="html-previewer"
       class="size-full"
       :srcdoc="code"
-      sandbox="allow-scripts allow-same-origin"
+      sandbox="allow-scripts"
       :frameborder="0"
       @load="updateHeight"
     />

--- a/test/core/models.test.ts
+++ b/test/core/models.test.ts
@@ -33,6 +33,7 @@ import {
   resolveEnableAnimate,
   resolveEnableCaret,
   resolveFloatingDelay,
+  resolveHtmlPreviewSandbox,
   resolvePreloadNodeRenderers,
   rotateImagePreviewRight,
   setMermaidMeasuredHeight,
@@ -347,6 +348,13 @@ describe('core models', () => {
     expect(createHtmlPreviewModel({ type: 'code', value: ' <div /> ' } as never)).toEqual({
       code: '<div />',
     })
+    expect(resolveHtmlPreviewSandbox(undefined)).toBe('allow-scripts')
+    expect(resolveHtmlPreviewSandbox(true)).toBe('allow-scripts')
+    expect(resolveHtmlPreviewSandbox({
+      html: {
+        sandbox: 'allow-scripts allow-same-origin allow-forms',
+      },
+    })).toBe('allow-scripts allow-same-origin allow-forms')
     expect(resolveFloatingDelay([10, 20])).toEqual({ show: 10, hide: 20 })
     expect(createFloatingStyle({ x: 1, y: 2, strategy: 'fixed' })).toEqual({
       position: 'fixed',

--- a/test/vue/html-previewer.test.ts
+++ b/test/vue/html-previewer.test.ts
@@ -1,0 +1,51 @@
+// @vitest-environment happy-dom
+import type { CodeNode, MarkdownAstParser, NodeRenderers } from 'vue-stream-markdown'
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import { defineComponent, h } from 'vue'
+import HtmlPreviewer from '../../packages/vue/src/components/previewers/html.vue'
+import { useContext } from '../../packages/vue/src/composables'
+
+function mountHtmlPreviewer(previewers?: unknown) {
+  const WrappedHtmlPreviewer = defineComponent({
+    setup() {
+      const { provideContext } = useContext()
+
+      provideContext({
+        previewers: previewers as never,
+      })
+
+      return () => h(HtmlPreviewer, {
+        markdownParser: {} as MarkdownAstParser,
+        nodeRenderers: {} as NodeRenderers,
+        node: {
+          type: 'code',
+          lang: 'html',
+          value: '<div>Hello</div>',
+        } as CodeNode,
+        nodeKey: 'stream-markdown-block-0-code-0',
+        deep: 1,
+      })
+    },
+  })
+
+  return mount(WrappedHtmlPreviewer)
+}
+
+describe('html previewer', () => {
+  it('uses the safer default iframe sandbox', () => {
+    const wrapper = mountHtmlPreviewer()
+
+    expect(wrapper.find('iframe').attributes('sandbox')).toBe('allow-scripts')
+  })
+
+  it('allows configuring the iframe sandbox', () => {
+    const wrapper = mountHtmlPreviewer({
+      html: {
+        sandbox: 'allow-scripts allow-same-origin allow-forms',
+      },
+    })
+
+    expect(wrapper.find('iframe').attributes('sandbox')).toBe('allow-scripts allow-same-origin allow-forms')
+  })
+})


### PR DESCRIPTION
Close #50 

Remove the default warning by removing allow-same-origin which increase security