### PR TITLE
fix: preserve stable streaming AST blocks

### DIFF
--- a/packages/markmend/ast/src/parser.ts
+++ b/packages/markmend/ast/src/parser.ts
@@ -142,7 +142,19 @@ export class MarkdownAstParser {
       const syntaxLoading = isLastBlock && blocks[index] !== content
       const tailTextLoading = isLastBlock && this.mode === 'streaming'
 
-      // check if the ast is cached
+      // Reuse the AST from the previous parse when the block stayed at the
+      // same position and its processed content did not change. This is the
+      // primary reuse path for streaming documents and does not depend on the
+      // bounded content-keyed cache retaining the whole stable prefix.
+      const previousContent = this.contents[index]
+      const previousAst = this.asts[index]
+      if (previousAst && previousContent === content) {
+        asts.push(applyLoadingState(previousAst, syntaxLoading, tailTextLoading))
+        continue
+      }
+
+      // Fall back to the content-keyed cache for blocks that moved or
+      // reappeared at a different position.
       if (this.astCache.has(content)) {
         const ast = this.astCache.get(content)!
         asts.push(applyLoadingState(ast, syntaxLoading, tailTextLoading))

--- a/test/markmend/parser.test.ts
+++ b/test/markmend/parser.test.ts
@@ -280,6 +280,45 @@ describe('markdown-parser', () => {
     expect(spy).toHaveBeenCalledTimes(1)
   })
 
+  it('should use the content cache when a block moves to another position', () => {
+    const parser = new MarkdownAstParser({
+      mode: 'streaming',
+      parseMarkdownIntoBlocks: content => content.split('\n'),
+    })
+    const spy = vi.spyOn(parser as unknown as { markdownToAst: (content: string) => SyntaxTree }, 'markdownToAst')
+
+    parser.parseMarkdown('first\nsecond')
+    parser.parseMarkdown('new\nfirst\nsecond')
+
+    expect(spy).toHaveBeenCalledTimes(3)
+  })
+
+  it('should reuse the previous ast for unchanged blocks beyond cache capacity', () => {
+    const blocks = Array.from(
+      { length: 150 },
+      (_, index) => `block-${index}`,
+    )
+    const parser = new MarkdownAstParser({
+      mode: 'streaming',
+      parseMarkdownIntoBlocks: content => content.split('\n'),
+    })
+    const spy = vi.spyOn(parser as unknown as { markdownToAst: (content: string) => SyntaxTree }, 'markdownToAst')
+
+    const initial = parser.parseMarkdown(blocks.join('\n'))
+
+    spy.mockClear()
+    blocks[149] += '-tail'
+    const updated = parser.parseMarkdown(blocks.join('\n'))
+
+    const changedCompletedBlocks = initial.asts
+      .slice(0, -1)
+      .filter((ast, index) => ast !== updated.asts[index])
+      .length
+
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(changedCompletedBlocks).toBe(0)
+  })
+
   it('should skip postprocess when mode is static', () => {
     const parser = new MarkdownAstParser({
       mode: 'static',


### PR DESCRIPTION
## Summary

Reuse unchanged block ASTs by position before falling back to the LRU cache. Add regressions for long stable prefixes and moved blocks.

Fixes #57

## Checks

- 647 tests passed
- TypeScript, ESLint, and @markmend/ast build passed
