### PR TITLE
fix: ignore inline code markers during streaming completion

### DIFF
--- a/packages/markmend/core/src/preprocess/emphasis.ts
+++ b/packages/markmend/core/src/preprocess/emphasis.ts
@@ -8,11 +8,15 @@ import {
 } from './pattern'
 import {
   calculateParagraphOffset,
+  findClosedCodeBlockRanges,
+  findInlineCodeRanges,
   getLastParagraphWithIndex,
   isInsideUnclosedCodeBlock,
+  isPositionInRanges,
   isWithinHtmlTag,
   isWithinLinkOrImageUrl,
   isWithinMathBlock,
+  maskInlineCodeMarkdownMarkers,
   removeUrlsFromText,
 } from './utils'
 
@@ -31,9 +35,13 @@ export function fixEmphasis(content: string): string {
   // Find the last paragraph
   const lines = content.split('\n')
   const { lastParagraph, startIndex: paragraphStartIndex } = getLastParagraphWithIndex(content)
+  const codeBlockRanges = findClosedCodeBlockRanges(lastParagraph)
+  const inlineCodeRanges = findInlineCodeRanges(lastParagraph, codeBlockRanges)
 
-  // Remove code blocks from the last paragraph to avoid processing emphasis inside them
-  const lastParagraphWithoutCodeBlocks = lastParagraph.replace(codeBlockPattern, '')
+  // Remove code blocks and mask Markdown markers inside inline code to avoid
+  // treating code content as incomplete emphasis.
+  const lastParagraphWithoutInlineCodeMarkers = maskInlineCodeMarkdownMarkers(lastParagraph, inlineCodeRanges)
+  const lastParagraphWithoutCodeBlocks = lastParagraphWithoutInlineCodeMarkers.replace(codeBlockPattern, '')
   // Remove URLs to avoid counting markdown syntax inside URLs (URLs may contain _, *, ~)
   const lastParagraphWithoutCodeBlocksAndUrls = removeUrlsFromText(lastParagraphWithoutCodeBlocks)
 
@@ -64,6 +72,9 @@ export function fixEmphasis(content: string): string {
 
     // Search backwards in the original lastParagraph to find the last * that's not in a URL
     for (let i = lastParagraph.length - 1; i >= 0; i--) {
+      if (isPositionInRanges(i, codeBlockRanges) || isPositionInRanges(i, inlineCodeRanges))
+        continue
+
       if (lastParagraph[i] === '*') {
         const absolutePos = paragraphOffset + i
         // Skip if it's part of ** (we already removed those)
@@ -108,6 +119,9 @@ export function fixEmphasis(content: string): string {
 
     // Search backwards in the original lastParagraph to find the last _ that's not in a URL
     for (let i = lastParagraph.length - 1; i >= 0; i--) {
+      if (isPositionInRanges(i, codeBlockRanges) || isPositionInRanges(i, inlineCodeRanges))
+        continue
+
       if (lastParagraph[i] === '_') {
         const absolutePos = paragraphOffset + i
         // Skip if it's part of __ (we already removed those)
@@ -161,6 +175,9 @@ export function fixEmphasis(content: string): string {
     const paragraphOffset = calculateParagraphOffset(paragraphStartIndex, lines)
     let lastUnderscorePosInOriginal = -1
     for (let i = lastParagraph.length - 1; i >= 0; i--) {
+      if (isPositionInRanges(i, codeBlockRanges) || isPositionInRanges(i, inlineCodeRanges))
+        continue
+
       if (lastParagraph[i] === '_' && (i === 0 || lastParagraph[i - 1] !== '_')) {
         const absolutePos = paragraphOffset + i
         if (!isWithinMathBlock(content, absolutePos) && !isWithinLinkOrImageUrl(content, absolutePos) && !isWithinHtmlTag(content, absolutePos)) {

--- a/packages/markmend/core/src/preprocess/strong.ts
+++ b/packages/markmend/core/src/preprocess/strong.ts
@@ -10,11 +10,15 @@ import {
 import {
   appendBeforeTrailingWhitespace,
   calculateParagraphOffset,
+  findClosedCodeBlockRanges,
+  findInlineCodeRanges,
   getLastParagraphWithIndex,
   isInsideUnclosedCodeBlock,
+  isPositionInRanges,
   isWithinHtmlTag,
   isWithinLinkOrImageUrl,
   isWithinMathBlock,
+  maskInlineCodeMarkdownMarkers,
   removeMathBlocksFromText,
   removeUrlsFromText,
 } from './utils'
@@ -65,9 +69,13 @@ export function fixStrong(
   // paragraph that contains the unclosed strong markers.
   const lines = content.split('\n')
   const { lastParagraph, startIndex: paragraphStartIndex } = getLastParagraphWithIndex(content, true)
+  const codeBlockRanges = findClosedCodeBlockRanges(lastParagraph)
+  const inlineCodeRanges = findInlineCodeRanges(lastParagraph, codeBlockRanges)
 
-  // Remove code blocks from the last paragraph to avoid processing strong inside them
-  const lastParagraphWithoutCodeBlocks = lastParagraph.replace(codeBlockPattern, '')
+  // Remove code blocks and mask Markdown markers inside inline code to avoid
+  // treating code content as incomplete strong emphasis.
+  const lastParagraphWithoutInlineCodeMarkers = maskInlineCodeMarkdownMarkers(lastParagraph, inlineCodeRanges)
+  const lastParagraphWithoutCodeBlocks = lastParagraphWithoutInlineCodeMarkers.replace(codeBlockPattern, '')
   // Remove URLs to avoid counting markdown syntax inside URLs (URLs may contain _, *, ~)
   const lastParagraphWithoutCodeBlocksAndUrls = removeUrlsFromText(lastParagraphWithoutCodeBlocks)
   // Remove math blocks to avoid counting markdown syntax inside math (math may contain **, __, etc.)
@@ -103,6 +111,8 @@ export function fixStrong(
         i += 2 // Skip the next two backticks
         continue
       }
+      if (isPositionInRanges(i, inlineCodeRanges))
+        continue
       // Skip if inside code block
       if (inCodeBlock) {
         continue
@@ -144,6 +154,8 @@ export function fixStrong(
         i += 2 // Skip the next two backticks
         continue
       }
+      if (isPositionInRanges(i, inlineCodeRanges))
+        continue
       // Skip if inside code block
       if (inCodeBlock) {
         continue
@@ -182,7 +194,7 @@ export function fixStrong(
     // Recalculate after removal. Again, skip any trailing empty line so we
     // still operate on the actual last non-empty paragraph.
     const { lastParagraph: newLastParagraph } = getLastParagraphWithIndex(content, true)
-    const newLastParagraphWithoutCodeBlocks = newLastParagraph.replace(codeBlockPattern, '')
+    const newLastParagraphWithoutCodeBlocks = maskInlineCodeMarkdownMarkers(newLastParagraph).replace(codeBlockPattern, '')
     const newLastParagraphWithoutCodeBlocksAndUrls = removeUrlsFromText(newLastParagraphWithoutCodeBlocks)
     const newLastParagraphWithoutCodeBlocksAndUrlsAndMath = removeMathBlocksFromText(newLastParagraphWithoutCodeBlocksAndUrls, options)
     const newAsteriskMatches = newLastParagraphWithoutCodeBlocksAndUrlsAndMath.match(doubleAsteriskPattern)
@@ -208,7 +220,7 @@ export function fixStrong(
     // Recalculate after removal. Again, skip any trailing empty line so we
     // still operate on the actual last non-empty paragraph.
     const { lastParagraph: newLastParagraph } = getLastParagraphWithIndex(content, true)
-    const newLastParagraphWithoutCodeBlocks = newLastParagraph.replace(codeBlockPattern, '')
+    const newLastParagraphWithoutCodeBlocks = maskInlineCodeMarkdownMarkers(newLastParagraph).replace(codeBlockPattern, '')
     const newLastParagraphWithoutCodeBlocksAndUrls = removeUrlsFromText(newLastParagraphWithoutCodeBlocks)
     const newLastParagraphWithoutCodeBlocksAndUrlsAndMath = removeMathBlocksFromText(newLastParagraphWithoutCodeBlocksAndUrls, options)
     const newUnderscoreMatches = newLastParagraphWithoutCodeBlocksAndUrlsAndMath.match(doubleUnderscorePattern)
@@ -268,7 +280,7 @@ export function fixStrong(
     // But only if we didn't just remove a trailing single *
     if (!removedTrailingSingle) {
       const { lastParagraph: currentLastParagraph } = getLastParagraphWithIndex(content, true)
-      const currentLastParagraphWithoutCodeBlocks = currentLastParagraph.replace(codeBlockPattern, '')
+      const currentLastParagraphWithoutCodeBlocks = maskInlineCodeMarkdownMarkers(currentLastParagraph).replace(codeBlockPattern, '')
       const currentLastParagraphWithoutCodeBlocksAndUrls = removeUrlsFromText(currentLastParagraphWithoutCodeBlocks)
       const currentLastParagraphWithoutCodeBlocksAndUrlsAndMath = removeMathBlocksFromText(currentLastParagraphWithoutCodeBlocksAndUrls, options)
       const withoutDoubleAsterisk = currentLastParagraphWithoutCodeBlocksAndUrlsAndMath.replace(doubleAsteriskPattern, '')
@@ -288,7 +300,7 @@ export function fixStrong(
     // But only if we didn't just remove a trailing single _
     if (!removedTrailingSingle) {
       const { lastParagraph: currentLastParagraph } = getLastParagraphWithIndex(content)
-      const currentLastParagraphWithoutCodeBlocks = currentLastParagraph.replace(codeBlockPattern, '')
+      const currentLastParagraphWithoutCodeBlocks = maskInlineCodeMarkdownMarkers(currentLastParagraph).replace(codeBlockPattern, '')
       const currentLastParagraphWithoutCodeBlocksAndUrls = removeUrlsFromText(currentLastParagraphWithoutCodeBlocks)
       const currentLastParagraphWithoutCodeBlocksAndUrlsAndMath = removeMathBlocksFromText(currentLastParagraphWithoutCodeBlocksAndUrls, options)
       const withoutDoubleUnderscore = currentLastParagraphWithoutCodeBlocksAndUrlsAndMath.replace(doubleUnderscorePattern, '')

--- a/packages/markmend/core/src/preprocess/utils.ts
+++ b/packages/markmend/core/src/preprocess/utils.ts
@@ -264,6 +264,29 @@ export function findInlineCodeRanges(
 }
 
 /**
+ * Mask Markdown marker characters inside inline code while preserving all
+ * other characters and the original string offsets.
+ */
+export function maskInlineCodeMarkdownMarkers(
+  content: string,
+  inlineCodeRanges: TextRange[] = findInlineCodeRanges(content),
+): string {
+  if (!inlineCodeRanges.length)
+    return content
+
+  const characters = content.split('')
+  for (const range of inlineCodeRanges) {
+    for (let index = range.start; index < range.end; index++) {
+      const character = characters[index]
+      if (character === '*' || character === '_' || character === '~')
+        characters[index] = ' '
+    }
+  }
+
+  return characters.join('')
+}
+
+/**
  * Check if a position is within a math block (between $ or $$ delimiters)
  *
  * Note: we intentionally ignore single `$` here so that currency values

--- a/test/markmend/preprocess/test-cases.ts
+++ b/test/markmend/preprocess/test-cases.ts
@@ -388,6 +388,16 @@ export const emphasisTestCases: TestCasesByCategory = {
       expected: '__bold__ and _italic_',
     },
     {
+      description: 'should ignore _ inside inline code',
+      input: '`a_b`',
+      expected: '`a_b`',
+    },
+    {
+      description: 'should still complete _ outside inline code',
+      input: '`a_b` and _italic',
+      expected: '`a_b` and _italic_',
+    },
+    {
       description: 'should only process last paragraph',
       input: 'Para1 _unclosed\n\nPara2 _text',
       expected: 'Para1 _unclosed\n\nPara2 _text_',
@@ -570,6 +580,16 @@ export const strongTestCases: TestCasesByCategory = {
       description: 'should complete __ with trailing _',
       input: 'Hello __world_',
       expected: 'Hello __world__',
+    },
+    {
+      description: 'should ignore __ inside inline code',
+      input: '`a__b`',
+      expected: '`a__b`',
+    },
+    {
+      description: 'should still complete __ outside inline code',
+      input: '`a__b` and __bold',
+      expected: '`a__b` and __bold__',
     },
     {
       description: 'should not modify closed __',


### PR DESCRIPTION
## Summary

Ignore Markdown markers inside inline code during streaming emphasis completion.

Fixes #59

## Checks

- 655 tests passed
- TypeScript, ESLint, and @markmend/core build passed
