### PR TITLE
fix: ignore invalid underscore emphasis markers

### DIFF
--- a/packages/markmend/core/src/preprocess/emphasis.ts
+++ b/packages/markmend/core/src/preprocess/emphasis.ts
@@ -17,7 +17,9 @@ import {
   isWithinLinkOrImageUrl,
   isWithinMathBlock,
   maskInlineCodeMarkdownMarkers,
+  maskInvalidUnderscoreMarkers,
   removeUrlsFromText,
+  shouldIgnoreUnderscoreMarker,
 } from './utils'
 
 /**
@@ -44,16 +46,17 @@ export function fixEmphasis(content: string): string {
   const lastParagraphWithoutCodeBlocks = lastParagraphWithoutInlineCodeMarkers.replace(codeBlockPattern, '')
   // Remove URLs to avoid counting markdown syntax inside URLs (URLs may contain _, *, ~)
   const lastParagraphWithoutCodeBlocksAndUrls = removeUrlsFromText(lastParagraphWithoutCodeBlocks)
+  const lastParagraphForMarkerCounting = maskInvalidUnderscoreMarkers(lastParagraphWithoutCodeBlocksAndUrls)
 
   // Check asterisk emphasis first (original behavior)
   // Remove ** to count only single *
-  const withoutDoubleAsterisk = lastParagraphWithoutCodeBlocksAndUrls.replace(doubleAsteriskPattern, '')
+  const withoutDoubleAsterisk = lastParagraphForMarkerCounting.replace(doubleAsteriskPattern, '')
   const asteriskMatches = withoutDoubleAsterisk.match(singleAsteriskPattern)
   const asteriskCount = asteriskMatches ? asteriskMatches.length : 0
 
   // Check underscore emphasis
   // Remove __ to count only single _
-  const withoutDoubleUnderscore = lastParagraphWithoutCodeBlocksAndUrls.replace(doubleUnderscorePattern, '')
+  const withoutDoubleUnderscore = lastParagraphForMarkerCounting.replace(doubleUnderscorePattern, '')
   const underscoreMatches = withoutDoubleUnderscore.match(singleUnderscorePattern)
   const underscoreCount = underscoreMatches ? underscoreMatches.length : 0
 
@@ -128,6 +131,8 @@ export function fixEmphasis(content: string): string {
         if (i > 0 && lastParagraph[i - 1] === '_') {
           continue
         }
+        if (shouldIgnoreUnderscoreMarker(lastParagraph, i))
+          continue
         // Skip if it's in a URL, math block, or HTML tag
         if (!isWithinMathBlock(content, absolutePos) && !isWithinLinkOrImageUrl(content, absolutePos) && !isWithinHtmlTag(content, absolutePos)) {
           lastUnderscorePos = i
@@ -179,6 +184,8 @@ export function fixEmphasis(content: string): string {
         continue
 
       if (lastParagraph[i] === '_' && (i === 0 || lastParagraph[i - 1] !== '_')) {
+        if (shouldIgnoreUnderscoreMarker(lastParagraph, i))
+          continue
         const absolutePos = paragraphOffset + i
         if (!isWithinMathBlock(content, absolutePos) && !isWithinLinkOrImageUrl(content, absolutePos) && !isWithinHtmlTag(content, absolutePos)) {
           lastUnderscorePosInOriginal = absolutePos

--- a/packages/markmend/core/src/preprocess/strong.ts
+++ b/packages/markmend/core/src/preprocess/strong.ts
@@ -19,8 +19,10 @@ import {
   isWithinLinkOrImageUrl,
   isWithinMathBlock,
   maskInlineCodeMarkdownMarkers,
+  maskInvalidUnderscoreMarkers,
   removeMathBlocksFromText,
   removeUrlsFromText,
+  shouldIgnoreUnderscoreMarker,
 } from './utils'
 
 /**
@@ -80,6 +82,7 @@ export function fixStrong(
   const lastParagraphWithoutCodeBlocksAndUrls = removeUrlsFromText(lastParagraphWithoutCodeBlocks)
   // Remove math blocks to avoid counting markdown syntax inside math (math may contain **, __, etc.)
   const lastParagraphWithoutCodeBlocksAndUrlsAndMath = removeMathBlocksFromText(lastParagraphWithoutCodeBlocksAndUrls, options)
+  const lastParagraphForMarkerCounting = maskInvalidUnderscoreMarkers(lastParagraphWithoutCodeBlocksAndUrlsAndMath)
 
   // Check if content ends with a single * or _ (not ** or __)
   const endsWithSingleAsterisk = content.endsWith('*') && !content.endsWith('**')
@@ -90,7 +93,7 @@ export function fixStrong(
   const asteriskCount = asteriskMatches ? asteriskMatches.length : 0
 
   // Count __ in the last paragraph only (excluding code blocks, URLs, and math blocks)
-  const underscoreMatches = lastParagraphWithoutCodeBlocksAndUrlsAndMath.match(doubleUnderscorePattern)
+  const underscoreMatches = lastParagraphForMarkerCounting.match(doubleUnderscorePattern)
   const underscoreCount = underscoreMatches ? underscoreMatches.length : 0
 
   // Track what needs to be done
@@ -162,6 +165,10 @@ export function fixStrong(
       }
       // Check for __
       if (lastParagraph.substring(i, i + 2) === '__') {
+        if (shouldIgnoreUnderscoreMarker(lastParagraph, i, 2)) {
+          i += 1
+          continue
+        }
         actualLastUnderscorePos = i
         i += 1 // Skip the second _
       }
@@ -175,7 +182,7 @@ export function fixStrong(
       return content
     }
 
-    const afterLast = lastParagraphWithoutCodeBlocksAndUrlsAndMath.substring(lastParagraphWithoutCodeBlocksAndUrlsAndMath.lastIndexOf('__') + 2).trim()
+    const afterLast = lastParagraphForMarkerCounting.substring(lastParagraphForMarkerCounting.lastIndexOf('__') + 2).trim()
 
     if (afterLast.length > 0) {
       needsUnderscoreCompletion = true
@@ -223,11 +230,12 @@ export function fixStrong(
     const newLastParagraphWithoutCodeBlocks = maskInlineCodeMarkdownMarkers(newLastParagraph).replace(codeBlockPattern, '')
     const newLastParagraphWithoutCodeBlocksAndUrls = removeUrlsFromText(newLastParagraphWithoutCodeBlocks)
     const newLastParagraphWithoutCodeBlocksAndUrlsAndMath = removeMathBlocksFromText(newLastParagraphWithoutCodeBlocksAndUrls, options)
-    const newUnderscoreMatches = newLastParagraphWithoutCodeBlocksAndUrlsAndMath.match(doubleUnderscorePattern)
+    const newLastParagraphForMarkerCounting = maskInvalidUnderscoreMarkers(newLastParagraphWithoutCodeBlocksAndUrlsAndMath)
+    const newUnderscoreMatches = newLastParagraphForMarkerCounting.match(doubleUnderscorePattern)
     const newUnderscoreCount = newUnderscoreMatches ? newUnderscoreMatches.length : 0
     if (newUnderscoreCount % 2 === 1) {
-      const lastUnderscorePos = newLastParagraphWithoutCodeBlocksAndUrlsAndMath.lastIndexOf('__')
-      const afterLast = newLastParagraphWithoutCodeBlocksAndUrlsAndMath.substring(lastUnderscorePos + 2).trim()
+      const lastUnderscorePos = newLastParagraphForMarkerCounting.lastIndexOf('__')
+      const afterLast = newLastParagraphForMarkerCounting.substring(lastUnderscorePos + 2).trim()
       if (afterLast.length > 0) {
         needsUnderscoreCompletion = true
         needsUnderscoreRemoval = false
@@ -264,7 +272,7 @@ export function fixStrong(
   if (needsAsteriskCompletion && needsUnderscoreCompletion) {
     // Both need completion - complete the one that appears first
     const firstAsteriskPos = lastParagraphWithoutCodeBlocksAndUrlsAndMath.indexOf('**')
-    const firstUnderscorePos = lastParagraphWithoutCodeBlocksAndUrlsAndMath.indexOf('__')
+    const firstUnderscorePos = lastParagraphForMarkerCounting.indexOf('__')
     if (firstAsteriskPos < firstUnderscorePos) {
       // Asterisk appears first, complete underscore first, then asterisk
       return appendBeforeTrailingWhitespace(content, '__**')
@@ -303,7 +311,7 @@ export function fixStrong(
       const currentLastParagraphWithoutCodeBlocks = maskInlineCodeMarkdownMarkers(currentLastParagraph).replace(codeBlockPattern, '')
       const currentLastParagraphWithoutCodeBlocksAndUrls = removeUrlsFromText(currentLastParagraphWithoutCodeBlocks)
       const currentLastParagraphWithoutCodeBlocksAndUrlsAndMath = removeMathBlocksFromText(currentLastParagraphWithoutCodeBlocksAndUrls, options)
-      const withoutDoubleUnderscore = currentLastParagraphWithoutCodeBlocksAndUrlsAndMath.replace(doubleUnderscorePattern, '')
+      const withoutDoubleUnderscore = maskInvalidUnderscoreMarkers(currentLastParagraphWithoutCodeBlocksAndUrlsAndMath).replace(doubleUnderscorePattern, '')
       const singleUnderscoreMatches = withoutDoubleUnderscore.match(singleUnderscorePattern)
       const singleUnderscoreCount = singleUnderscoreMatches ? singleUnderscoreMatches.length : 0
       if (singleUnderscoreCount % 2 === 1) {

--- a/packages/markmend/core/src/preprocess/utils.ts
+++ b/packages/markmend/core/src/preprocess/utils.ts
@@ -286,6 +286,89 @@ export function maskInlineCodeMarkdownMarkers(
   return characters.join('')
 }
 
+const unicodeWordCharacterPattern = /[\p{L}\p{N}\p{M}]/u
+
+function isUnicodeWordCharacterAt(content: string, index: number): boolean {
+  if (index < 0 || index >= content.length)
+    return false
+
+  let characterIndex = index
+  const characterCode = content.charCodeAt(characterIndex)
+  // If the position points to the low surrogate of a supplementary
+  // character, move to the code point's starting position.
+  if (characterCode >= 0xDC00 && characterCode <= 0xDFFF)
+    characterIndex -= 1
+
+  const codePoint = content.codePointAt(characterIndex)
+  return codePoint !== undefined
+    && unicodeWordCharacterPattern.test(String.fromCodePoint(codePoint))
+}
+
+/**
+ * Check whether a character is escaped by an odd number of backslashes.
+ */
+export function isEscapedCharacter(content: string, index: number): boolean {
+  let backslashCount = 0
+  for (let i = index - 1; i >= 0 && content[i] === '\\'; i -= 1)
+    backslashCount += 1
+
+  return backslashCount % 2 === 1
+}
+
+/**
+ * Check whether an underscore run is inside a word.
+ *
+ * CommonMark does not allow underscore emphasis to open or close inside a
+ * word. Keeping this check separate lets streaming preprocessors use the
+ * same rule for both `_` and `__` markers.
+ */
+export function isUnderscoreInsideWord(
+  content: string,
+  start: number,
+  length = 1,
+): boolean {
+  return isUnicodeWordCharacterAt(content, start - 1)
+    && isUnicodeWordCharacterAt(content, start + length)
+}
+
+/**
+ * Check whether an underscore run should be ignored as an emphasis marker.
+ */
+export function shouldIgnoreUnderscoreMarker(
+  content: string,
+  start: number,
+  length = 1,
+): boolean {
+  return isEscapedCharacter(content, start)
+    || isUnderscoreInsideWord(content, start, length)
+}
+
+/**
+ * Mask escaped and intraword underscore runs while preserving string offsets.
+ */
+export function maskInvalidUnderscoreMarkers(content: string): string {
+  const characters = content.split('')
+
+  for (let index = 0; index < content.length;) {
+    if (content[index] !== '_') {
+      index += 1
+      continue
+    }
+
+    const runStart = index
+    while (index < content.length && content[index] === '_')
+      index += 1
+
+    const runLength = index - runStart
+    if (shouldIgnoreUnderscoreMarker(content, runStart, runLength)) {
+      for (let markerIndex = runStart; markerIndex < index; markerIndex += 1)
+        characters[markerIndex] = ' '
+    }
+  }
+
+  return characters.join('')
+}
+
 /**
  * Check if a position is within a math block (between $ or $$ delimiters)
  *

--- a/test/markmend/preprocess/test-cases.ts
+++ b/test/markmend/preprocess/test-cases.ts
@@ -388,6 +388,16 @@ export const emphasisTestCases: TestCasesByCategory = {
       expected: '__bold__ and _italic_',
     },
     {
+      description: 'should not complete an underscore inside a word',
+      input: 'a_b',
+      expected: 'a_b',
+    },
+    {
+      description: 'should not complete an escaped underscore',
+      input: 'a\\_b',
+      expected: 'a\\_b',
+    },
+    {
       description: 'should ignore _ inside inline code',
       input: '`a_b`',
       expected: '`a_b`',
@@ -575,6 +585,16 @@ export const strongTestCases: TestCasesByCategory = {
       description: 'should complete unclosed __',
       input: 'Hello __world',
       expected: 'Hello __world__',
+    },
+    {
+      description: 'should not complete __ inside a word',
+      input: 'a__b',
+      expected: 'a__b',
+    },
+    {
+      description: 'should not complete escaped __',
+      input: 'a\\__b',
+      expected: 'a\\__b',
     },
     {
       description: 'should complete __ with trailing _',


### PR DESCRIPTION
Fixes #61

Ignore escaped and intraword `_`/`__` markers during streaming completion, with regression tests.

Tests: `pnpm vitest run`, `pnpm typecheck`