### PR TITLE
fix(core): treat hex values as resolved colors in theme variable normalization

### DIFF
--- a/packages/core/src/utils/theme.ts
+++ b/packages/core/src/utils/theme.ts
@@ -1,8 +1,8 @@
-const CSS_COLOR_FUNCTION_PATTERN = /^(?:hsl|rgb|oklch|lab|lch)\(/
+const CSS_RESOLVED_COLOR_PATTERN = /^(?:#|(?:hsl|rgb|oklch|lab|lch)\()/
 
 export function normalizeThemeVariableValue(value: string): string | undefined {
   const normalizedValue = value.trim()
-  if (!normalizedValue || CSS_COLOR_FUNCTION_PATTERN.test(normalizedValue))
+  if (!normalizedValue || CSS_RESOLVED_COLOR_PATTERN.test(normalizedValue))
     return undefined
 
   return `hsl(${normalizedValue})`

--- a/test/core/utils.test.ts
+++ b/test/core/utils.test.ts
@@ -5,6 +5,7 @@ import {
   getTransitionName,
   normalizeAnimationDuration,
   normalizeCssSize,
+  normalizeThemeVariableValue,
   resolveTableAlign,
   resolveTextAnimationSplit,
   shouldAnimateNode,
@@ -73,6 +74,17 @@ describe('core utilities', () => {
     expect(normalizeAnimationDuration(undefined)).toBeUndefined()
     expect(normalizeCssSize(320)).toBe('320px')
     expect(normalizeCssSize('60vh')).toBe('60vh')
+  })
+
+  it('wraps bare hsl channels and leaves resolved theme colors untouched', () => {
+    expect(normalizeThemeVariableValue('30 29% 95%')).toBe('hsl(30 29% 95%)')
+    expect(normalizeThemeVariableValue(' 0 0% 100% ')).toBe('hsl(0 0% 100%)')
+    expect(normalizeThemeVariableValue('#fff')).toBeUndefined()
+    expect(normalizeThemeVariableValue('#f5f1ed')).toBeUndefined()
+    expect(normalizeThemeVariableValue('hsl(30 29% 95%)')).toBeUndefined()
+    expect(normalizeThemeVariableValue('rgb(245 241 237)')).toBeUndefined()
+    expect(normalizeThemeVariableValue('oklch(0.96 0.01 70)')).toBeUndefined()
+    expect(normalizeThemeVariableValue('')).toBeUndefined()
   })
 
   it('resolves table alignment and unwraps table cell children', () => {


### PR DESCRIPTION
## The problem

When the host app's shadcn variables hold hex colors, everything rendered in `#stream-markdown-overlay` loses its colors: the fullscreen table/code panel becomes a transparent `fixed` layer with the page showing through it, and tooltips, dropdowns and the image viewer render without backgrounds or borders. Nothing errors — the declarations are silently invalid, so the symptom is far from the cause.

The cause is one normalization step in `packages/core/src/utils/theme.ts`:

```ts
const CSS_COLOR_FUNCTION_PATTERN = /^(?:hsl|rgb|oklch|lab|lch)\(/

normalizeThemeVariableValue('30 29% 95%')  // => 'hsl(30 29% 95%)'  ✓ Tailwind v3 channels, wrapped as intended
normalizeThemeVariableValue('#f5f1ed')     // => 'hsl(#f5f1ed)'     ✗ invalid CSS
```

`readThemeVariables` copies the `SHADCN_SCHEMAS` custom properties onto the overlay, re-wrapping bare-channel values in `hsl()` (the Tailwind v3 / shadcn convention). Hex is already a resolved color, but it doesn't match the pattern, so it takes the wrapping branch and comes out invalid. The browser then drops every declaration that reads the variable.

## Why Tailwind v4 apps hit this by default

Tailwind v4 themes hold resolved colors, and production builds minify with lightningcss, which rewrites colors to their shortest form — hex:

```css
/* source  */  --background: rgb(245 241 237);
/* shipped */  --background: #f5f1ed;
```

So even apps that write `rgb()` or `oklch()` in source usually ship hex; hand-written hex themes hit it directly.

## Reproduction

```css
:root { --background: #f5f1ed }
```

Render a markdown table or code block and open it fullscreen. Expected: the panel has the `#f5f1ed` background. Actual: the panel is transparent, and inspecting `#stream-markdown-overlay` shows `--background: hsl(#f5f1ed)`, marked invalid.

## The fix

```diff
-const CSS_COLOR_FUNCTION_PATTERN = /^(?:hsl|rgb|oklch|lab|lch)\(/
+const CSS_RESOLVED_COLOR_PATTERN = /^(?:#|(?:hsl|rgb|oklch|lab|lch)\()/
```

Hex values are now skipped like the color-function notations — the overlay inherits the valid value from the host page instead of receiving a wrapped copy. Bare HSL channels keep working exactly as before; this only widens what counts as "already resolved". (The constant is renamed because it no longer matches only color functions; it is module-private, so there is no public API change.)

## Tests

`normalizeThemeVariableValue` had no direct coverage; this adds a case to `test/core/utils.test.ts`:

```ts
expect(normalizeThemeVariableValue('30 29% 95%')).toBe('hsl(30 29% 95%)')
expect(normalizeThemeVariableValue(' 0 0% 100% ')).toBe('hsl(0 0% 100%)')
expect(normalizeThemeVariableValue('#fff')).toBeUndefined()
expect(normalizeThemeVariableValue('#f5f1ed')).toBeUndefined()
expect(normalizeThemeVariableValue('hsl(30 29% 95%)')).toBeUndefined()
expect(normalizeThemeVariableValue('rgb(245 241 237)')).toBeUndefined()
expect(normalizeThemeVariableValue('oklch(0.96 0.01 70)')).toBeUndefined()
expect(normalizeThemeVariableValue('')).toBeUndefined()
```

The hex assertions fail on `main` with `expected 'hsl(#fff)' to be undefined`.

## Note

Drafted with Claude (Fable), reviewed by hand, and currently running in production in our own application through a local `patch-package` patch carrying exactly this change.