### PR TITLE
perf(markmend): optimize streaming markdown processing

### DIFF
--- a/benchmark/markmend-parser.bench.ts
+++ b/benchmark/markmend-parser.bench.ts
@@ -46,21 +46,6 @@ function postnormalizeDeletingPositions(data: SyntaxTree): SyntaxTree {
   return removePositions(postFixFootnote(data))
 }
 
-function copyWithoutPositions<T extends PositionableNode>(node: T): T {
-  const { children, position: _position, ...rest } = node
-  if (!children)
-    return rest as T
-
-  return {
-    ...rest,
-    children: children.map(child => copyWithoutPositions(child)),
-  } as T
-}
-
-function postnormalizeWithPositionlessCopy(data: SyntaxTree): SyntaxTree {
-  return copyWithoutPositions(postFixFootnote(data))
-}
-
 function createPositionedParser(): MarkdownAstParser {
   return new MarkdownAstParser({
     mode: 'streaming',
@@ -72,13 +57,6 @@ function createDeletePositionParser(): MarkdownAstParser {
   return new MarkdownAstParser({
     mode: 'streaming',
     postnormalize: postnormalizeDeletingPositions,
-  })
-}
-
-function createPositionlessCopyParser(): MarkdownAstParser {
-  return new MarkdownAstParser({
-    mode: 'streaming',
-    postnormalize: postnormalizeWithPositionlessCopy,
   })
 }
 
@@ -98,7 +76,7 @@ function parseStreamdownBlock(processor: Processor, content: string): number {
 
 const implementations: ParserBenchmarkImplementation[] = [
   {
-    name: 'markmend',
+    name: 'markmend/with-position',
     coldParse(content) {
       const parser = createPositionedParser()
       const result = parser.parseMarkdown(content)
@@ -132,14 +110,14 @@ const implementations: ParserBenchmarkImplementation[] = [
     },
   },
   {
-    name: 'markmend/copy-no-position',
+    name: 'markmend',
     coldParse(content) {
-      const parser = createPositionlessCopyParser()
+      const parser = new MarkdownAstParser({ mode: 'streaming' })
       const result = parser.parseMarkdown(content)
       return result.asts.reduce((total, ast) => total + ast.children.length, 0)
     },
     runStreamingSession(inputs) {
-      const parser = createPositionlessCopyParser()
+      const parser = new MarkdownAstParser({ mode: 'streaming' })
       let checksum = 0
       for (const input of inputs) {
         const result = parser.parseMarkdown(input)
@@ -326,7 +304,7 @@ function benchmarkMarkmendPipeline(
     }, options)
 
     bench('ast conversion copying without positions', () => {
-      const parser = createPositionlessCopyParser()
+      const parser = new MarkdownAstParser({ mode: 'streaming' })
       let checksum = 0
       for (const content of astMissContents)
         checksum += parser.markdownToAst(content).children.length
@@ -366,7 +344,7 @@ function benchmarkMarkmendPipeline(
     }, options)
 
     bench('full parser session copying without positions', () => {
-      const parser = createPositionlessCopyParser()
+      const parser = new MarkdownAstParser({ mode: 'streaming' })
       let checksum = 0
       for (const input of inputs) {
         const result = parser.parseMarkdown(input)
@@ -433,7 +411,7 @@ const retainedBaseline = createPositionedParser()
   .parseMarkdown(largeDocument)
 const retainedDeletingPositions = createDeletePositionParser()
   .parseMarkdown(largeDocument)
-const retainedCopyingWithoutPositions = createPositionlessCopyParser()
+const retainedCopyingWithoutPositions = new MarkdownAstParser({ mode: 'streaming' })
   .parseMarkdown(largeDocument)
 const retainedBaselineBytes = Buffer.byteLength(JSON.stringify(retainedBaseline.asts))
 const retainedDeletingPositionsBytes = Buffer.byteLength(JSON.stringify(retainedDeletingPositions.asts))

--- a/benchmark/markmend-parser.bench.ts
+++ b/benchmark/markmend-parser.bench.ts
@@ -1,12 +1,17 @@
 import type { Processor } from 'unified'
+import type { SyntaxTree } from '../packages/markmend/ast/src'
 import { createMarkdownParser } from 'comark'
 import remarkGfm from 'remark-gfm'
 import remarkParse from 'remark-parse'
 import remend from 'remend'
-import { parseMarkdownIntoBlocks } from 'streamdown'
+import { parseMarkdownIntoBlocks as parseStreamdownBlocks } from 'streamdown'
 import { unified } from 'unified'
 import { bench, describe } from 'vitest'
 import { MarkdownAstParser } from '../packages/markmend/ast/src'
+import {
+  MarkdownProcessor,
+  parseMarkdownIntoBlocks as parseMarkmendBlocks,
+} from '../packages/markmend/core/src'
 
 type MaybePromise<T> = Promise<T> | T
 
@@ -55,7 +60,7 @@ const implementations: ParserBenchmarkImplementation[] = [
     name: 'streamdown/remend',
     coldParse(content) {
       const processor = createStreamdownProcessor()
-      const blocks = parseMarkdownIntoBlocks(remend(content))
+      const blocks = parseStreamdownBlocks(remend(content))
       return blocks.reduce(
         (total, block) => total + parseStreamdownBlock(processor, block),
         0,
@@ -67,7 +72,7 @@ const implementations: ParserBenchmarkImplementation[] = [
       let previousBlocks: string[] = []
 
       for (const input of inputs) {
-        const blocks = parseMarkdownIntoBlocks(remend(input))
+        const blocks = parseStreamdownBlocks(remend(input))
         for (let index = 0; index < blocks.length; index++) {
           const block = blocks[index]!
           if (block === previousBlocks[index])
@@ -128,6 +133,117 @@ function benchmarkStreamingSession(
         options,
       )
     }
+  })
+}
+
+function normalizeSemanticBlocks(blocks: string[]): string[] {
+  return blocks
+    .filter(block => block.trim().length > 0)
+    .map(block => block.trimEnd())
+}
+
+function assertEquivalentSemanticBlocks(
+  name: string,
+  inputs: readonly string[],
+): void {
+  for (let index = 0; index < inputs.length; index++) {
+    const input = inputs[index]!
+    const markmendBlocks = normalizeSemanticBlocks(parseMarkmendBlocks(input))
+    const streamdownBlocks = normalizeSemanticBlocks(parseStreamdownBlocks(input))
+    const differingBlockIndex = Math.max(
+      markmendBlocks.findIndex((block, blockIndex) => block !== streamdownBlocks[blockIndex]),
+      streamdownBlocks.findIndex((block, blockIndex) => block !== markmendBlocks[blockIndex]),
+    )
+
+    if (
+      markmendBlocks.length !== streamdownBlocks.length
+      || differingBlockIndex !== -1
+    ) {
+      throw new Error(
+        [
+          `Semantic block segmentation differs for ${name} input ${index + 1}`,
+          `at block ${differingBlockIndex + 1}`,
+          `(counts: ${markmendBlocks.length}/${streamdownBlocks.length})`,
+          `(Markmend: ${JSON.stringify(markmendBlocks[differingBlockIndex])}`,
+          `Streamdown: ${JSON.stringify(streamdownBlocks[differingBlockIndex])})`,
+        ].join(' '),
+      )
+    }
+  }
+}
+
+function benchmarkMarkmendPipeline(
+  name: string,
+  inputs: readonly string[],
+  options = standardOptions,
+): void {
+  const processor = new MarkdownProcessor()
+  const normalizedInputs = inputs.map(input => processor.normalize(input))
+  const blockInputs = normalizedInputs.map(input => processor.parseMarkdownIntoBlocks(input))
+  const astMissContents: string[] = []
+  const recordingParser = new MarkdownAstParser({ mode: 'streaming' })
+  const markdownToAst = recordingParser.markdownToAst.bind(recordingParser)
+  recordingParser.markdownToAst = (content) => {
+    astMissContents.push(content)
+    return markdownToAst(content)
+  }
+  for (const input of inputs)
+    recordingParser.parseMarkdown(input)
+
+  describe(`markmend pipeline breakdown > ${name} (${inputs.length} ticks)`, () => {
+    bench('normalize', () => {
+      let checksum = 0
+      for (const input of inputs)
+        checksum += processor.normalize(input).length
+      return checksum
+    }, options)
+
+    bench('block segmentation', () => {
+      let checksum = 0
+      for (const input of normalizedInputs)
+        checksum += processor.parseMarkdownIntoBlocks(input).length
+      return checksum
+    }, options)
+
+    bench('tail completion', () => {
+      let checksum = 0
+      for (const blocks of blockInputs) {
+        const tail = blocks.at(-1)
+        if (tail)
+          checksum += processor.preprocess(tail, { singleDollarTextMath: false }).length
+      }
+      return checksum
+    }, options)
+
+    bench('ast conversion on cache misses', () => {
+      const parser = new MarkdownAstParser({ mode: 'streaming' })
+      let checksum = 0
+      for (const content of astMissContents)
+        checksum += parser.markdownToAst(content).children.length
+
+      return checksum
+    }, options)
+
+    bench('pipeline excluding AST conversion', () => {
+      const parser = new MarkdownAstParser({ mode: 'streaming' })
+      const emptyAst: SyntaxTree = { type: 'root', children: [] }
+      parser.markdownToAst = () => emptyAst
+
+      let checksum = 0
+      for (const input of inputs)
+        checksum += parser.parseMarkdown(input).asts.length
+      return checksum
+    }, options)
+
+    bench('full parser session', () => {
+      const parser = new MarkdownAstParser({ mode: 'streaming' })
+      let checksum = 0
+      for (const input of inputs) {
+        const result = parser.parseMarkdown(input)
+        checksum += result.asts.length
+      }
+      return checksum
+    }, options)
   })
 }
 
@@ -200,7 +316,18 @@ const stablePrefixInputs = createGrowingInputs(
 const appendingBlockInputs = createAppendingBlockInputs(16)
 const middleEditInputs = createMiddleEditInputs(48, 8)
 
+assertEquivalentSemanticBlocks('short document', [shortDocument])
+assertEquivalentSemanticBlocks('medium document', [mediumDocument])
+assertEquivalentSemanticBlocks('large document', [largeDocument])
+assertEquivalentSemanticBlocks('growing single paragraph', growingParagraph)
+assertEquivalentSemanticBlocks('large stable prefix with growing tail', stablePrefixInputs)
+assertEquivalentSemanticBlocks('appending complete blocks', appendingBlockInputs)
+assertEquivalentSemanticBlocks('editing a middle block', middleEditInputs)
+
 benchmarkStreamingSession('growing single paragraph', growingParagraph)
 benchmarkStreamingSession('large stable prefix with growing tail', stablePrefixInputs, largeOptions)
 benchmarkStreamingSession('appending complete blocks', appendingBlockInputs)
 benchmarkStreamingSession('editing a middle block', middleEditInputs, largeOptions)
+
+benchmarkMarkmendPipeline('growing single paragraph', growingParagraph)
+benchmarkMarkmendPipeline('large stable prefix with growing tail', stablePrefixInputs, largeOptions)

--- a/benchmark/markmend-parser.bench.ts
+++ b/benchmark/markmend-parser.bench.ts
@@ -1,0 +1,206 @@
+import type { Processor } from 'unified'
+import { createMarkdownParser } from 'comark'
+import remarkGfm from 'remark-gfm'
+import remarkParse from 'remark-parse'
+import remend from 'remend'
+import { parseMarkdownIntoBlocks } from 'streamdown'
+import { unified } from 'unified'
+import { bench, describe } from 'vitest'
+import { MarkdownAstParser } from '../packages/markmend/ast/src'
+
+type MaybePromise<T> = Promise<T> | T
+
+interface ParserBenchmarkImplementation {
+  coldParse: (content: string) => MaybePromise<number>
+  name: string
+  runStreamingSession: (inputs: readonly string[]) => MaybePromise<number>
+}
+
+const standardOptions = { iterations: 100 }
+const largeOptions = { iterations: 20 }
+
+function createStreamdownProcessor(): Processor {
+  return unified()
+    .use(remarkParse)
+    .use(remarkGfm)
+    .freeze()
+}
+
+function parseStreamdownBlock(processor: Processor, content: string): number {
+  const tree = processor.runSync(processor.parse(content), content) as {
+    children?: unknown[]
+  }
+  return tree.children?.length ?? 0
+}
+
+const implementations: ParserBenchmarkImplementation[] = [
+  {
+    name: 'markmend',
+    coldParse(content) {
+      const parser = new MarkdownAstParser({ mode: 'streaming' })
+      const result = parser.parseMarkdown(content)
+      return result.asts.reduce((total, ast) => total + ast.children.length, 0)
+    },
+    runStreamingSession(inputs) {
+      const parser = new MarkdownAstParser({ mode: 'streaming' })
+      let checksum = 0
+      for (const input of inputs) {
+        const result = parser.parseMarkdown(input)
+        checksum += result.asts.reduce((total, ast) => total + ast.children.length, 0)
+      }
+      return checksum
+    },
+  },
+  {
+    name: 'streamdown/remend',
+    coldParse(content) {
+      const processor = createStreamdownProcessor()
+      const blocks = parseMarkdownIntoBlocks(remend(content))
+      return blocks.reduce(
+        (total, block) => total + parseStreamdownBlock(processor, block),
+        0,
+      )
+    },
+    runStreamingSession(inputs) {
+      const processor = createStreamdownProcessor()
+      let checksum = 0
+      let previousBlocks: string[] = []
+
+      for (const input of inputs) {
+        const blocks = parseMarkdownIntoBlocks(remend(input))
+        for (let index = 0; index < blocks.length; index++) {
+          const block = blocks[index]!
+          if (block === previousBlocks[index])
+            continue
+          checksum += parseStreamdownBlock(processor, block)
+        }
+        previousBlocks = blocks
+      }
+
+      return checksum
+    },
+  },
+  {
+    name: 'comark',
+    async coldParse(content) {
+      const parser = createMarkdownParser()
+      const result = await parser(content, { streaming: true })
+      return result.nodes.length
+    },
+    async runStreamingSession(inputs) {
+      const parser = createMarkdownParser()
+      let checksum = 0
+      for (const input of inputs) {
+        const result = await parser(input, { streaming: true })
+        checksum += result.nodes.length
+      }
+      return checksum
+    },
+  },
+]
+
+function benchmarkColdParse(
+  name: string,
+  input: string,
+  options = standardOptions,
+): void {
+  describe(`cold AST parse > ${name}`, () => {
+    for (const implementation of implementations) {
+      bench(
+        implementation.name,
+        async () => implementation.coldParse(input),
+        options,
+      )
+    }
+  })
+}
+
+function benchmarkStreamingSession(
+  name: string,
+  inputs: readonly string[],
+  options = standardOptions,
+): void {
+  describe(`stateful streaming > ${name} (${inputs.length} ticks)`, () => {
+    for (const implementation of implementations) {
+      bench(
+        implementation.name,
+        async () => implementation.runStreamingSession(inputs),
+        options,
+      )
+    }
+  })
+}
+
+function createDocument(sectionCount: number): string {
+  return Array.from({ length: sectionCount }, (_, index) => `
+## Section ${index + 1}
+
+This paragraph contains **bold**, *italic*, a [link](https://example.com/${index}), and \`code\`.
+
+- Item one
+- Item two
+- Item three
+`).join('\n')
+}
+
+function createGrowingInputs(content: string, chunkSize: number, prefix = ''): string[] {
+  const inputs: string[] = []
+  for (let end = chunkSize; end < content.length; end += chunkSize)
+    inputs.push(prefix + content.slice(0, end))
+  inputs.push(prefix + content)
+  return inputs
+}
+
+function createAppendingBlockInputs(blockCount: number): string[] {
+  const blocks = Array.from({ length: blockCount }, (_, index) => `
+## Generated section ${index + 1}
+
+Streaming block ${index + 1} contains **formatted text** and a short explanation.
+`)
+  return blocks.map((_, index) => blocks.slice(0, index + 1).join('\n'))
+}
+
+function createMiddleEditInputs(blockCount: number, editCount: number): string[] {
+  const blocks = Array.from({ length: blockCount }, (_, index) => `
+## Stable section ${index + 1}
+
+Stable content for section ${index + 1}.
+`)
+  const middleIndex = Math.floor(blockCount / 2)
+
+  return Array.from({ length: editCount }, (_, editIndex) => {
+    const editedBlocks = [...blocks]
+    editedBlocks[middleIndex] = `
+## Edited section
+
+Middle content revision ${editIndex + 1} with **changing text**.
+`
+    return editedBlocks.join('\n')
+  })
+}
+
+const shortDocument = createDocument(2)
+const mediumDocument = createDocument(24)
+const largeDocument = createDocument(96)
+
+benchmarkColdParse('short document', shortDocument)
+benchmarkColdParse('medium document', mediumDocument)
+benchmarkColdParse('large document', largeDocument, largeOptions)
+
+const growingParagraph = createGrowingInputs(
+  'A single paragraph with **bold text**, *emphasis*, links, and inline code. '.repeat(12),
+  48,
+)
+const stablePrefix = `${createDocument(64)}\n\n## Live response\n\n`
+const stablePrefixInputs = createGrowingInputs(
+  'The model is generating **one changing tail block** while every earlier block remains stable. '.repeat(8),
+  48,
+  stablePrefix,
+)
+const appendingBlockInputs = createAppendingBlockInputs(16)
+const middleEditInputs = createMiddleEditInputs(48, 8)
+
+benchmarkStreamingSession('growing single paragraph', growingParagraph)
+benchmarkStreamingSession('large stable prefix with growing tail', stablePrefixInputs, largeOptions)
+benchmarkStreamingSession('appending complete blocks', appendingBlockInputs)
+benchmarkStreamingSession('editing a middle block', middleEditInputs, largeOptions)

--- a/benchmark/markmend-parser.bench.ts
+++ b/benchmark/markmend-parser.bench.ts
@@ -1,5 +1,6 @@
 import type { Processor } from 'unified'
 import type { SyntaxTree } from '../packages/markmend/ast/src'
+import { Buffer } from 'node:buffer'
 import { createMarkdownParser } from 'comark'
 import remarkGfm from 'remark-gfm'
 import remarkParse from 'remark-parse'
@@ -7,7 +8,7 @@ import remend from 'remend'
 import { parseMarkdownIntoBlocks as parseStreamdownBlocks } from 'streamdown'
 import { unified } from 'unified'
 import { bench, describe } from 'vitest'
-import { MarkdownAstParser } from '../packages/markmend/ast/src'
+import { MarkdownAstParser, postFixFootnote } from '../packages/markmend/ast/src'
 import {
   MarkdownProcessor,
   parseMarkdownIntoBlocks as parseMarkmendBlocks,
@@ -23,6 +24,63 @@ interface ParserBenchmarkImplementation {
 
 const standardOptions = { iterations: 100 }
 const largeOptions = { iterations: 20 }
+
+interface PositionableNode {
+  children?: PositionableNode[]
+  position?: unknown
+}
+
+function removePositions<T extends PositionableNode>(node: T): T {
+  delete node.position
+  const children = node.children
+  if (!children)
+    return node
+
+  for (const child of children)
+    removePositions(child)
+
+  return node
+}
+
+function postnormalizeDeletingPositions(data: SyntaxTree): SyntaxTree {
+  return removePositions(postFixFootnote(data))
+}
+
+function copyWithoutPositions<T extends PositionableNode>(node: T): T {
+  const { children, position: _position, ...rest } = node
+  if (!children)
+    return rest as T
+
+  return {
+    ...rest,
+    children: children.map(child => copyWithoutPositions(child)),
+  } as T
+}
+
+function postnormalizeWithPositionlessCopy(data: SyntaxTree): SyntaxTree {
+  return copyWithoutPositions(postFixFootnote(data))
+}
+
+function createPositionedParser(): MarkdownAstParser {
+  return new MarkdownAstParser({
+    mode: 'streaming',
+    postnormalize: postFixFootnote,
+  })
+}
+
+function createDeletePositionParser(): MarkdownAstParser {
+  return new MarkdownAstParser({
+    mode: 'streaming',
+    postnormalize: postnormalizeDeletingPositions,
+  })
+}
+
+function createPositionlessCopyParser(): MarkdownAstParser {
+  return new MarkdownAstParser({
+    mode: 'streaming',
+    postnormalize: postnormalizeWithPositionlessCopy,
+  })
+}
 
 function createStreamdownProcessor(): Processor {
   return unified()
@@ -42,12 +100,46 @@ const implementations: ParserBenchmarkImplementation[] = [
   {
     name: 'markmend',
     coldParse(content) {
-      const parser = new MarkdownAstParser({ mode: 'streaming' })
+      const parser = createPositionedParser()
       const result = parser.parseMarkdown(content)
       return result.asts.reduce((total, ast) => total + ast.children.length, 0)
     },
     runStreamingSession(inputs) {
-      const parser = new MarkdownAstParser({ mode: 'streaming' })
+      const parser = createPositionedParser()
+      let checksum = 0
+      for (const input of inputs) {
+        const result = parser.parseMarkdown(input)
+        checksum += result.asts.reduce((total, ast) => total + ast.children.length, 0)
+      }
+      return checksum
+    },
+  },
+  {
+    name: 'markmend/delete-position',
+    coldParse(content) {
+      const parser = createDeletePositionParser()
+      const result = parser.parseMarkdown(content)
+      return result.asts.reduce((total, ast) => total + ast.children.length, 0)
+    },
+    runStreamingSession(inputs) {
+      const parser = createDeletePositionParser()
+      let checksum = 0
+      for (const input of inputs) {
+        const result = parser.parseMarkdown(input)
+        checksum += result.asts.reduce((total, ast) => total + ast.children.length, 0)
+      }
+      return checksum
+    },
+  },
+  {
+    name: 'markmend/copy-no-position',
+    coldParse(content) {
+      const parser = createPositionlessCopyParser()
+      const result = parser.parseMarkdown(content)
+      return result.asts.reduce((total, ast) => total + ast.children.length, 0)
+    },
+    runStreamingSession(inputs) {
+      const parser = createPositionlessCopyParser()
       let checksum = 0
       for (const input of inputs) {
         const result = parser.parseMarkdown(input)
@@ -181,7 +273,7 @@ function benchmarkMarkmendPipeline(
   const normalizedInputs = inputs.map(input => processor.normalize(input))
   const blockInputs = normalizedInputs.map(input => processor.parseMarkdownIntoBlocks(input))
   const astMissContents: string[] = []
-  const recordingParser = new MarkdownAstParser({ mode: 'streaming' })
+  const recordingParser = createPositionedParser()
   const markdownToAst = recordingParser.markdownToAst.bind(recordingParser)
   recordingParser.markdownToAst = (content) => {
     astMissContents.push(content)
@@ -216,7 +308,25 @@ function benchmarkMarkmendPipeline(
     }, options)
 
     bench('ast conversion on cache misses', () => {
-      const parser = new MarkdownAstParser({ mode: 'streaming' })
+      const parser = createPositionedParser()
+      let checksum = 0
+      for (const content of astMissContents)
+        checksum += parser.markdownToAst(content).children.length
+
+      return checksum
+    }, options)
+
+    bench('ast conversion deleting positions', () => {
+      const parser = createDeletePositionParser()
+      let checksum = 0
+      for (const content of astMissContents)
+        checksum += parser.markdownToAst(content).children.length
+
+      return checksum
+    }, options)
+
+    bench('ast conversion copying without positions', () => {
+      const parser = createPositionlessCopyParser()
       let checksum = 0
       for (const content of astMissContents)
         checksum += parser.markdownToAst(content).children.length
@@ -225,7 +335,7 @@ function benchmarkMarkmendPipeline(
     }, options)
 
     bench('pipeline excluding AST conversion', () => {
-      const parser = new MarkdownAstParser({ mode: 'streaming' })
+      const parser = createPositionedParser()
       const emptyAst: SyntaxTree = { type: 'root', children: [] }
       parser.markdownToAst = () => emptyAst
 
@@ -236,7 +346,27 @@ function benchmarkMarkmendPipeline(
     }, options)
 
     bench('full parser session', () => {
-      const parser = new MarkdownAstParser({ mode: 'streaming' })
+      const parser = createPositionedParser()
+      let checksum = 0
+      for (const input of inputs) {
+        const result = parser.parseMarkdown(input)
+        checksum += result.asts.length
+      }
+      return checksum
+    }, options)
+
+    bench('full parser session deleting positions', () => {
+      const parser = createDeletePositionParser()
+      let checksum = 0
+      for (const input of inputs) {
+        const result = parser.parseMarkdown(input)
+        checksum += result.asts.length
+      }
+      return checksum
+    }, options)
+
+    bench('full parser session copying without positions', () => {
+      const parser = createPositionlessCopyParser()
       let checksum = 0
       for (const input of inputs) {
         const result = parser.parseMarkdown(input)
@@ -298,6 +428,24 @@ Middle content revision ${editIndex + 1} with **changing text**.
 const shortDocument = createDocument(2)
 const mediumDocument = createDocument(24)
 const largeDocument = createDocument(96)
+
+const retainedBaseline = createPositionedParser()
+  .parseMarkdown(largeDocument)
+const retainedDeletingPositions = createDeletePositionParser()
+  .parseMarkdown(largeDocument)
+const retainedCopyingWithoutPositions = createPositionlessCopyParser()
+  .parseMarkdown(largeDocument)
+const retainedBaselineBytes = Buffer.byteLength(JSON.stringify(retainedBaseline.asts))
+const retainedDeletingPositionsBytes = Buffer.byteLength(JSON.stringify(retainedDeletingPositions.asts))
+const retainedCopyingWithoutPositionsBytes = Buffer.byteLength(JSON.stringify(retainedCopyingWithoutPositions.asts))
+
+console.warn('large document retained AST JSON size', {
+  baselineBytes: retainedBaselineBytes,
+  copyingReduction: `${((1 - retainedCopyingWithoutPositionsBytes / retainedBaselineBytes) * 100).toFixed(1)}%`,
+  copyingWithoutPositionsBytes: retainedCopyingWithoutPositionsBytes,
+  deletingPositionsBytes: retainedDeletingPositionsBytes,
+  deletingReduction: `${((1 - retainedDeletingPositionsBytes / retainedBaselineBytes) * 100).toFixed(1)}%`,
+})
 
 benchmarkColdParse('short document', shortDocument)
 benchmarkColdParse('medium document', mediumDocument)

--- a/benchmark/markmend-position-memory.ts
+++ b/benchmark/markmend-position-memory.ts
@@ -1,0 +1,97 @@
+import type { SyntaxTree } from '../packages/markmend/ast/src'
+import process from 'node:process'
+import { MarkdownAstParser, postFixFootnote } from '../packages/markmend/ast/src'
+
+interface PositionableNode {
+  children?: PositionableNode[]
+  position?: unknown
+}
+
+function removePositions<T extends PositionableNode>(node: T): T {
+  delete node.position
+  const children = node.children
+  if (!children)
+    return node
+
+  for (const child of children)
+    removePositions(child)
+
+  return node
+}
+
+function postnormalizeWithoutPositions(data: SyntaxTree): SyntaxTree {
+  return removePositions(postFixFootnote(data))
+}
+
+function copyWithoutPositions<T extends PositionableNode>(node: T): T {
+  const { children, position: _position, ...rest } = node
+  if (!children)
+    return rest as T
+
+  return {
+    ...rest,
+    children: children.map(child => copyWithoutPositions(child)),
+  } as T
+}
+
+function postnormalizeWithPositionlessCopy(data: SyntaxTree): SyntaxTree {
+  return copyWithoutPositions(postFixFootnote(data))
+}
+
+function createDocument(sectionCount: number): string {
+  return Array.from({ length: sectionCount }, (_, index) => `
+## Section ${index + 1}
+
+This paragraph contains **bold**, *italic*, a [link](https://example.com/${index}), and \`code\`.
+
+- Item one
+- Item two
+- Item three
+`).join('\n')
+}
+
+function collectGarbage(): void {
+  const gc = (globalThis as typeof globalThis & { gc?: () => void }).gc
+  if (!gc)
+    throw new Error('Run this script with --expose-gc')
+
+  for (let index = 0; index < 5; index++)
+    gc()
+}
+
+const mode = process.argv[2]
+if (mode !== 'baseline' && mode !== 'delete-position' && mode !== 'copy-no-position')
+  throw new Error('Expected baseline, delete-position, or copy-no-position mode')
+
+const content = createDocument(96)
+const createParser = mode === 'baseline'
+  ? () => new MarkdownAstParser({
+      mode: 'streaming',
+      postnormalize: postFixFootnote,
+    })
+  : () => new MarkdownAstParser({
+      mode: 'streaming',
+      postnormalize: mode === 'delete-position'
+        ? postnormalizeWithoutPositions
+        : postnormalizeWithPositionlessCopy,
+    })
+
+for (let index = 0; index < 5; index++)
+  createParser().parseMarkdown(content)
+
+collectGarbage()
+const before = process.memoryUsage().heapUsed
+const retainedParsers = Array.from({ length: 50 }, () => {
+  const parser = createParser()
+  parser.parseMarkdown(content)
+  return parser
+})
+collectGarbage()
+const after = process.memoryUsage().heapUsed
+
+console.warn(JSON.stringify({
+  bytesPerParser: Math.round((after - before) / retainedParsers.length),
+  heapDeltaBytes: after - before,
+  mode,
+  parserCount: retainedParsers.length,
+}))

--- a/benchmark/markmend-position-memory.ts
+++ b/benchmark/markmend-position-memory.ts
@@ -60,21 +60,34 @@ function collectGarbage(): void {
 }
 
 const mode = process.argv[2]
-if (mode !== 'baseline' && mode !== 'delete-position' && mode !== 'copy-no-position')
-  throw new Error('Expected baseline, delete-position, or copy-no-position mode')
+if (
+  mode !== 'baseline'
+  && mode !== 'delete-position'
+  && mode !== 'copy-no-position'
+  && mode !== 'production'
+) {
+  throw new Error('Expected baseline, delete-position, copy-no-position, or production mode')
+}
 
 const content = createDocument(96)
-const createParser = mode === 'baseline'
-  ? () => new MarkdownAstParser({
-      mode: 'streaming',
-      postnormalize: postFixFootnote,
-    })
-  : () => new MarkdownAstParser({
-      mode: 'streaming',
-      postnormalize: mode === 'delete-position'
-        ? postnormalizeWithoutPositions
-        : postnormalizeWithPositionlessCopy,
-    })
+let createParser: () => MarkdownAstParser
+if (mode === 'production') {
+  createParser = () => new MarkdownAstParser({ mode: 'streaming' })
+}
+else if (mode === 'baseline') {
+  createParser = () => new MarkdownAstParser({
+    mode: 'streaming',
+    postnormalize: postFixFootnote,
+  })
+}
+else {
+  createParser = () => new MarkdownAstParser({
+    mode: 'streaming',
+    postnormalize: mode === 'delete-position'
+      ? postnormalizeWithoutPositions
+      : postnormalizeWithPositionlessCopy,
+  })
+}
 
 for (let index = 0; index < 5; index++)
   createParser().parseMarkdown(content)

--- a/benchmark/markmend.bench.ts
+++ b/benchmark/markmend.bench.ts
@@ -1,0 +1,160 @@
+import { autoCloseMarkdown } from 'comark'
+import remend from 'remend'
+import { bench, describe } from 'vitest'
+import { preprocess } from '../packages/markmend/core/src/preprocess'
+
+type CompleteMarkdown = (content: string) => string
+
+const implementations: Array<{
+  name: string
+  complete: CompleteMarkdown
+}> = [
+  { name: 'markmend', complete: preprocess },
+  { name: 'streamdown/remend', complete: remend },
+  { name: 'comark', complete: autoCloseMarkdown },
+]
+
+const standardOptions = { iterations: 1000 }
+const pathologicalOptions = { iterations: 10 }
+
+function benchmarkInput(
+  category: string,
+  name: string,
+  input: string,
+  options = standardOptions,
+): void {
+  describe(`${category} > ${name}`, () => {
+    for (const implementation of implementations) {
+      bench(
+        implementation.name,
+        () => implementation.complete(input),
+        options,
+      )
+    }
+  })
+}
+
+function benchmarkStream(
+  category: string,
+  name: string,
+  inputs: readonly string[],
+): void {
+  describe(`${category} > ${name}`, () => {
+    for (const implementation of implementations) {
+      bench(
+        implementation.name,
+        () => {
+          for (const input of inputs)
+            implementation.complete(input)
+        },
+        standardOptions,
+      )
+    }
+  })
+}
+
+const mediumText = '# Heading\n\nThis is **bold** and *italic* text with `code` and ~~strikethrough~~'
+const longText = `
+# Complex Document
+
+This document contains **bold**, *italic*, and ***bold-italic*** text.
+It also has \`inline code\` and ~~strikethrough~~ formatting.
+
+Here's a [link](https://example.com) and an incomplete link [text](
+
+## Math Support
+
+Inline math: $E = mc^2$ and block math:
+
+$$
+\\int_0^\\infty x^2 dx
+`
+
+benchmarkInput('basic formatting', 'short text with incomplete bold', 'This is **bold text')
+benchmarkInput('basic formatting', 'medium text with mixed formatting', mediumText)
+benchmarkInput('basic formatting', 'long text with complex formatting', longText)
+
+benchmarkInput('incomplete patterns', 'bold (**)', 'Some text with **incomplete bold')
+benchmarkInput('incomplete patterns', 'italic (*)', 'Some text with *incomplete italic')
+benchmarkInput('incomplete patterns', 'italic (__)', 'Some text with __incomplete italic')
+benchmarkInput('incomplete patterns', 'inline code (`)', 'Some text with `incomplete code')
+benchmarkInput('incomplete patterns', 'strikethrough (~~)', 'Some text with ~~incomplete strikethrough')
+benchmarkInput('incomplete patterns', 'bold-italic (***)', 'Some text with ***incomplete bold-italic')
+benchmarkInput('incomplete patterns', 'link destination', 'Some text with [incomplete link](')
+benchmarkInput('incomplete patterns', 'link text', 'Some text with [incomplete')
+benchmarkInput('incomplete patterns', 'block math ($$)', '$$\nE = mc^2\n')
+
+const incompleteCodeBlock = '```javascript\nconst x = 1;\n'
+const completeCodeBlock = '```javascript\nconst x = 1;\n```'
+const multipleCodeBlocks = `
+\`\`\`javascript
+const x = 1;
+\`\`\`
+
+Some text
+
+\`\`\`python
+y = 2
+`
+
+benchmarkInput('code blocks', 'incomplete code block', incompleteCodeBlock)
+benchmarkInput('code blocks', 'complete code block', completeCodeBlock)
+benchmarkInput('code blocks', 'multiple code blocks (one incomplete)', multipleCodeBlocks)
+
+benchmarkStream('streaming simulation', 'bold text (10 steps)', [
+  '**',
+  '**B',
+  '**Bo',
+  '**Bol',
+  '**Bold',
+  '**Bold ',
+  '**Bold t',
+  '**Bold te',
+  '**Bold tex',
+  '**Bold text',
+])
+
+benchmarkStream('streaming simulation', 'inline code (6 steps)', [
+  '`',
+  '`c',
+  '`co',
+  '`cod',
+  '`code',
+  '`code`',
+])
+
+benchmarkInput('edge cases', 'empty string', '')
+benchmarkInput('edge cases', 'plain text', 'This is plain text without any markdown formatting.')
+benchmarkInput('edge cases', 'many asterisks', '****************************')
+benchmarkInput('edge cases', 'mixed emphasis markers', '**_*~`**_*~`**_*~`')
+benchmarkInput('edge cases', 'list with emphasis', '- **bold\n- *italic\n- `code')
+benchmarkInput('edge cases', 'underscores in math', '$x_1 + x_2 = x_')
+
+const largeDocument = `
+# Large Document Benchmark
+
+${'## Section\n\nThis is a paragraph with **bold**, *italic*, and `code` formatting.\n\n'.repeat(50)}
+
+## Code Section
+
+\`\`\`javascript
+${'const x = 1;\n'.repeat(100)}
+\`\`\`
+
+## More Content
+
+${'Regular paragraph text with some [links](https://example.com) and more content.\n\n'.repeat(50)}
+`
+
+benchmarkInput('large documents', 'realistic size', largeDocument)
+benchmarkInput('large documents', '2x realistic size', largeDocument + largeDocument)
+
+const bracketHeavyLine = 'const x = arr[i]; if (map[key]) { list[j] = grid[a][b]; }\n'
+const bracketHeavyCodeBlock = `\`\`\`ts\n${bracketHeavyLine.repeat(1000)}`
+
+benchmarkInput(
+  'pathological inputs',
+  'unclosed bracket-heavy code block (58k chars)',
+  bracketHeavyCodeBlock,
+  pathologicalOptions,
+)

--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "benchmark",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "bench:completion": "vitest bench --run markmend.bench.ts",
+    "bench:parser": "vitest bench --run markmend-parser.bench.ts"
+  },
+  "devDependencies": {
+    "comark": "catalog:benchmark",
+    "react": "catalog:benchmark",
+    "react-dom": "catalog:benchmark",
+    "remark-gfm": "catalog:benchmark",
+    "remark-parse": "catalog:benchmark",
+    "remend": "catalog:benchmark",
+    "streamdown": "catalog:benchmark",
+    "unified": "catalog:benchmark",
+    "vitest": "catalog:test"
+  }
+}

--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "bench:completion": "vitest bench --run markmend.bench.ts",
-    "bench:parser": "vitest bench --run markmend-parser.bench.ts"
+    "bench:parser": "vitest bench --run markmend-parser.bench.ts",
+    "bench:position-memory": "node --expose-gc --import tsx markmend-position-memory.ts"
   },
   "devDependencies": {
     "comark": "catalog:benchmark",

--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -190,7 +190,7 @@ Override individual built-in preprocess steps while keeping the default order.
 
 - **Type:** `(data: SyntaxTree) => SyntaxTree`
 
-Function to normalize the syntax tree after parsing but before postprocess. Used for basic AST normalization tasks, such as reorganizing footnote definitions.
+Function to normalize the syntax tree after parsing but before postprocess. The built-in implementation reorganizes footnote definitions and omits positional metadata to reduce retained memory.
 
 ### postprocess
 

--- a/docs/config/parser.md
+++ b/docs/config/parser.md
@@ -166,7 +166,7 @@ If you customize the preprocess pipeline, ensure you maintain these ordering rul
 - **Type:** `(data: SyntaxTree) => SyntaxTree`
 - **Default:** Built-in postnormalize function
 
-The `postnormalize` function is executed after the AST (Abstract Syntax Tree) is generated, but before `postprocess`. It is used for basic AST normalization tasks, such as reorganizing footnote definitions.
+The `postnormalize` function is executed after the AST (Abstract Syntax Tree) is generated, but before `postprocess`. It is used for basic AST normalization tasks, such as reorganizing footnote definitions. The built-in implementation also returns a copy without node `position` metadata to reduce retained memory. Replacing `postnormalize` gives you full control and can preserve positions when needed.
 
 ### How It Works
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "scripts": {
     "dev": "pnpm playground:dev",
     "build": "turbo run build \"--filter=./packages/*\" \"--filter=./packages/extensions/*\" \"--filter=./packages/markmend/*\"",
+    "bench:markmend": "vitest bench --run benchmark/markmend.bench.ts",
     "playground:dev": "pnpm -F nuxt-playground dev",
     "playground:build": "pnpm -F nuxt-playground generate",
     "playground:typecheck": "pnpm -F nuxt-playground typecheck",
@@ -65,7 +66,9 @@
     "@vitest/coverage-v8": "catalog:test",
     "@vue/test-utils": "catalog:test",
     "vitest": "catalog:test",
-    "@types/node": "catalog:types"
+    "@types/node": "catalog:types",
+    "comark": "0.6.2",
+    "remend": "1.3.1"
   },
   "simple-git-hooks": {
     "pre-commit": "pnpm nano-staged"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "scripts": {
     "dev": "pnpm playground:dev",
     "build": "turbo run build \"--filter=./packages/*\" \"--filter=./packages/extensions/*\" \"--filter=./packages/markmend/*\"",
-    "bench:markmend": "vitest bench --run benchmark/markmend.bench.ts",
+    "bench:markmend": "pnpm -F benchmark bench:completion",
+    "bench:markmend:parser": "pnpm -F benchmark bench:parser",
     "playground:dev": "pnpm -F nuxt-playground dev",
     "playground:build": "pnpm -F nuxt-playground generate",
     "playground:typecheck": "pnpm -F nuxt-playground typecheck",
@@ -66,9 +67,7 @@
     "@vitest/coverage-v8": "catalog:test",
     "@vue/test-utils": "catalog:test",
     "vitest": "catalog:test",
-    "@types/node": "catalog:types",
-    "comark": "0.6.2",
-    "remend": "1.3.1"
+    "@types/node": "catalog:types"
   },
   "simple-git-hooks": {
     "pre-commit": "pnpm nano-staged"

--- a/packages/markmend/ast/src/parser.ts
+++ b/packages/markmend/ast/src/parser.ts
@@ -25,6 +25,9 @@ export interface Options extends MarkdownAstParserOptions {
 
 export class MarkdownAstParser {
   private mode: Options['mode'] = 'streaming'
+  private normalizedContent = ''
+  private blocks: string[] = []
+  private hasSegmentedBlocks = false
   private contents: string[] = []
   private asts: SyntaxTree[] = []
   private astCache = new QuickLRU<string, SyntaxTree>({
@@ -101,14 +104,62 @@ export class MarkdownAstParser {
       lastLeafNode.loading = true
   }
 
+  private parseStreamingBlocks(data: string): string[] {
+    // Custom splitters may have document-wide semantics. Footnotes also force
+    // the default splitter to keep the entire document in one AST.
+    const shouldParseFully = (
+      Boolean(this.options.parseMarkdownIntoBlocks)
+      || !this.hasSegmentedBlocks
+      || !this.blocks.length
+      || !data.startsWith(this.normalizedContent)
+      || data.includes('[^')
+    )
+
+    if (shouldParseFully)
+      return this.processor.parseMarkdownIntoBlocks(data)
+
+    if (data === this.normalizedContent)
+      return this.blocks
+
+    // Reparse the previous tail block as well as the appended text because a
+    // new line can turn it into a list, setext heading, fenced block, and more.
+    // Skip trailing whitespace-only tokens so the semantic tail is included.
+    let reparseIndex = this.blocks.length - 1
+    while (reparseIndex > 0 && !this.blocks[reparseIndex]!.trim())
+      reparseIndex -= 1
+
+    const stableBlocks = this.blocks.slice(0, reparseIndex)
+    let stableLength = 0
+    for (const block of stableBlocks)
+      stableLength += block.length
+
+    const tailBlocks = this.processor.parseMarkdownIntoBlocks(data.slice(stableLength))
+    return [...stableBlocks, ...tailBlocks]
+  }
+
   private update(data: string) {
     data = this.processor.normalize(data)
 
     // Preserve multi-block segmentation when switching from streaming -> static at runtime.
     // Otherwise block keys collapse from N -> 1 and can trigger broad component remounts.
-    const blocks = this.mode === 'static' && this.contents.length <= 1
-      ? [data]
-      : this.processor.parseMarkdownIntoBlocks(data)
+    let blocks: string[]
+    let hasSegmentedBlocks: boolean
+    if (this.mode === 'static' && this.contents.length <= 1) {
+      blocks = [data]
+      hasSegmentedBlocks = false
+    }
+    else if (this.mode === 'streaming') {
+      blocks = this.parseStreamingBlocks(data)
+      hasSegmentedBlocks = true
+    }
+    else if (this.hasSegmentedBlocks && data === this.normalizedContent) {
+      blocks = this.blocks
+      hasSegmentedBlocks = true
+    }
+    else {
+      blocks = this.processor.parseMarkdownIntoBlocks(data)
+      hasSegmentedBlocks = true
+    }
 
     const asts: SyntaxTree[] = []
     const contents: string[] = []
@@ -169,6 +220,9 @@ export class MarkdownAstParser {
 
     this.asts = asts
     this.contents = contents
+    this.blocks = blocks
+    this.normalizedContent = data
+    this.hasSegmentedBlocks = hasSegmentedBlocks
   }
 
   private updateAstLoading(ast: SyntaxTree, loading: boolean) {

--- a/packages/markmend/ast/src/postprocess/index.ts
+++ b/packages/markmend/ast/src/postprocess/index.ts
@@ -1,11 +1,9 @@
 import type { SyntaxTree } from '../types'
-import { flow } from '@markmend/core'
 import { postFixFootnote } from './footnote'
+import { omitPositions } from './position'
 
 export function postnormalize(data: SyntaxTree): SyntaxTree {
-  return flow([
-    postFixFootnote,
-  ])(data)
+  return omitPositions(postFixFootnote(data))
 }
 
 export function postprocess(data: SyntaxTree): SyntaxTree {

--- a/packages/markmend/ast/src/postprocess/position.ts
+++ b/packages/markmend/ast/src/postprocess/position.ts
@@ -1,0 +1,15 @@
+interface PositionableNode {
+  children?: PositionableNode[]
+  position?: unknown
+}
+
+export function omitPositions<T extends PositionableNode>(node: T): T {
+  const { children, position: _position, ...nodeWithoutPosition } = node
+  if (!children)
+    return nodeWithoutPosition as T
+
+  return {
+    ...nodeWithoutPosition,
+    children: children.map(child => omitPositions(child)),
+  } as T
+}

--- a/packages/markmend/core/src/preprocess/context.ts
+++ b/packages/markmend/core/src/preprocess/context.ts
@@ -1,0 +1,95 @@
+import type { PreprocessContext } from '../types'
+import type { TextRange } from './utils'
+import {
+  findClosedCodeBlockRanges,
+  findInlineCodeRanges,
+  findLastParagraphStart,
+  isInsideUnclosedCodeBlock,
+
+} from './utils'
+
+export interface PreprocessParagraphAnalysis {
+  codeBlockRanges: TextRange[]
+  content: string
+  inlineCodeRanges: TextRange[]
+  isFullyCodeBlock: boolean
+  startIndex: number
+  startOffset: number
+}
+
+export interface PreprocessAnalysis {
+  content: string
+  hasUnclosedCodeBlock: boolean
+  lines: string[]
+  getLastParagraph: (skipTrailingEmpty?: boolean) => PreprocessParagraphAnalysis
+}
+
+const analysisCache = new WeakMap<PreprocessContext, PreprocessAnalysis>()
+
+function createParagraphAnalysis(
+  content: string,
+  lines: string[],
+  skipTrailingEmpty: boolean,
+): PreprocessParagraphAnalysis {
+  const startIndex = findLastParagraphStart(lines, skipTrailingEmpty)
+  const paragraphContent = lines.slice(startIndex).join('\n')
+  const codeBlockRanges = findClosedCodeBlockRanges(paragraphContent)
+  const inlineCodeRanges = findInlineCodeRanges(paragraphContent, codeBlockRanges)
+  const startOffset = startIndex === 0
+    ? 0
+    : lines.slice(0, startIndex).join('\n').length + 1
+  const isFullyCodeBlock = codeBlockRanges.some(range => (
+    paragraphContent.slice(0, range.start).trim() === ''
+    && paragraphContent.slice(range.end).trim() === ''
+  ))
+
+  return {
+    codeBlockRanges,
+    content: paragraphContent,
+    inlineCodeRanges,
+    isFullyCodeBlock,
+    startIndex,
+    startOffset,
+  }
+}
+
+function analyzePreprocessContent(content: string): PreprocessAnalysis {
+  const lines = content.split('\n')
+  const paragraphs = new Map<boolean, PreprocessParagraphAnalysis>()
+
+  return {
+    content,
+    hasUnclosedCodeBlock: isInsideUnclosedCodeBlock(content),
+    lines,
+    getLastParagraph(skipTrailingEmpty = false) {
+      let paragraph = paragraphs.get(skipTrailingEmpty)
+      if (!paragraph) {
+        paragraph = createParagraphAnalysis(content, lines, skipTrailingEmpty)
+        paragraphs.set(skipTrailingEmpty, paragraph)
+      }
+      return paragraph
+    },
+  }
+}
+
+export function createPreprocessContext(
+  context: PreprocessContext = {},
+): PreprocessContext {
+  return { ...context }
+}
+
+export function getPreprocessAnalysis(
+  content: string,
+  context?: PreprocessContext,
+): PreprocessAnalysis {
+  if (!context)
+    return analyzePreprocessContent(content)
+
+  const cached = analysisCache.get(context)
+  if (cached?.content === content)
+    return cached
+
+  const analysis = analyzePreprocessContent(content)
+  analysisCache.set(context, analysis)
+  return analysis
+}

--- a/packages/markmend/core/src/preprocess/context.ts
+++ b/packages/markmend/core/src/preprocess/context.ts
@@ -18,58 +18,100 @@ export interface PreprocessParagraphAnalysis {
 }
 
 export interface PreprocessAnalysis {
+  codeBlockRanges: TextRange[]
   content: string
   hasUnclosedCodeBlock: boolean
+  inlineCodeRanges: TextRange[]
+  isFullyCodeBlock: boolean
   lines: string[]
   getLastParagraph: (skipTrailingEmpty?: boolean) => PreprocessParagraphAnalysis
 }
 
 const analysisCache = new WeakMap<PreprocessContext, PreprocessAnalysis>()
 
-function createParagraphAnalysis(
-  content: string,
-  lines: string[],
-  skipTrailingEmpty: boolean,
-): PreprocessParagraphAnalysis {
-  const startIndex = findLastParagraphStart(lines, skipTrailingEmpty)
-  const paragraphContent = lines.slice(startIndex).join('\n')
-  const codeBlockRanges = findClosedCodeBlockRanges(paragraphContent)
-  const inlineCodeRanges = findInlineCodeRanges(paragraphContent, codeBlockRanges)
-  const startOffset = startIndex === 0
-    ? 0
-    : lines.slice(0, startIndex).join('\n').length + 1
-  const isFullyCodeBlock = codeBlockRanges.some(range => (
-    paragraphContent.slice(0, range.start).trim() === ''
-    && paragraphContent.slice(range.end).trim() === ''
-  ))
+class CachedParagraphAnalysis implements PreprocessParagraphAnalysis {
+  private cachedCodeBlockRanges?: TextRange[]
+  private cachedInlineCodeRanges?: TextRange[]
+  readonly content: string
+  readonly startIndex: number
+  readonly startOffset: number
 
-  return {
-    codeBlockRanges,
-    content: paragraphContent,
-    inlineCodeRanges,
-    isFullyCodeBlock,
-    startIndex,
-    startOffset,
+  constructor(lines: string[], skipTrailingEmpty: boolean) {
+    this.startIndex = findLastParagraphStart(lines, skipTrailingEmpty)
+    this.content = lines.slice(this.startIndex).join('\n')
+    this.startOffset = this.startIndex === 0
+      ? 0
+      : lines.slice(0, this.startIndex).join('\n').length + 1
+  }
+
+  get codeBlockRanges(): TextRange[] {
+    this.cachedCodeBlockRanges ??= findClosedCodeBlockRanges(this.content)
+    return this.cachedCodeBlockRanges
+  }
+
+  get inlineCodeRanges(): TextRange[] {
+    this.cachedInlineCodeRanges ??= findInlineCodeRanges(this.content, this.codeBlockRanges)
+    return this.cachedInlineCodeRanges
+  }
+
+  get isFullyCodeBlock(): boolean {
+    return this.codeBlockRanges.some(range => (
+      this.content.slice(0, range.start).trim() === ''
+      && this.content.slice(range.end).trim() === ''
+    ))
+  }
+}
+
+class CachedPreprocessAnalysis implements PreprocessAnalysis {
+  private cachedCodeBlockRanges?: TextRange[]
+  private cachedHasUnclosedCodeBlock?: boolean
+  private cachedInlineCodeRanges?: TextRange[]
+  private cachedLines?: string[]
+  private defaultParagraph?: PreprocessParagraphAnalysis
+  private trailingParagraph?: PreprocessParagraphAnalysis
+
+  constructor(readonly content: string) {}
+
+  get codeBlockRanges(): TextRange[] {
+    this.cachedCodeBlockRanges ??= findClosedCodeBlockRanges(this.content)
+    return this.cachedCodeBlockRanges
+  }
+
+  get hasUnclosedCodeBlock(): boolean {
+    this.cachedHasUnclosedCodeBlock ??= isInsideUnclosedCodeBlock(this.content)
+    return this.cachedHasUnclosedCodeBlock
+  }
+
+  get inlineCodeRanges(): TextRange[] {
+    this.cachedInlineCodeRanges ??= findInlineCodeRanges(this.content, this.codeBlockRanges)
+    return this.cachedInlineCodeRanges
+  }
+
+  get isFullyCodeBlock(): boolean {
+    return this.codeBlockRanges.some(range => (
+      this.content.slice(0, range.start).trim() === ''
+      && this.content.slice(range.end).trim() === ''
+    ))
+  }
+
+  get lines(): string[] {
+    this.cachedLines ??= this.content.split('\n')
+    return this.cachedLines
+  }
+
+  getLastParagraph(skipTrailingEmpty = false): PreprocessParagraphAnalysis {
+    if (skipTrailingEmpty) {
+      this.trailingParagraph ??= new CachedParagraphAnalysis(this.lines, true)
+      return this.trailingParagraph
+    }
+
+    this.defaultParagraph ??= new CachedParagraphAnalysis(this.lines, false)
+    return this.defaultParagraph
   }
 }
 
 function analyzePreprocessContent(content: string): PreprocessAnalysis {
-  const lines = content.split('\n')
-  const paragraphs = new Map<boolean, PreprocessParagraphAnalysis>()
-
-  return {
-    content,
-    hasUnclosedCodeBlock: isInsideUnclosedCodeBlock(content),
-    lines,
-    getLastParagraph(skipTrailingEmpty = false) {
-      let paragraph = paragraphs.get(skipTrailingEmpty)
-      if (!paragraph) {
-        paragraph = createParagraphAnalysis(content, lines, skipTrailingEmpty)
-        paragraphs.set(skipTrailingEmpty, paragraph)
-      }
-      return paragraph
-    },
-  }
+  return new CachedPreprocessAnalysis(content)
 }
 
 export function createPreprocessContext(

--- a/packages/markmend/core/src/preprocess/context.ts
+++ b/packages/markmend/core/src/preprocess/context.ts
@@ -1,16 +1,32 @@
 import type { PreprocessContext } from '../types'
 import type { TextRange } from './utils'
+import { codeBlockPattern } from './pattern'
 import {
   findClosedCodeBlockRanges,
   findInlineCodeRanges,
   findLastParagraphStart,
   isInsideUnclosedCodeBlock,
-
+  maskInlineCodeMarkdownMarkers,
+  maskInvalidAsteriskMarkers,
+  maskInvalidUnderscoreMarkers,
+  maskPairedMarkerRuns,
+  maskThematicBreakMarkers,
+  removeMathBlocksFromText,
+  removeUrlsFromText,
 } from './utils'
+
+export interface FormattingMarkerAnalysis {
+  maskedContent: string
+  singleAsteriskMarkers: string
+  singleUnderscoreMarkers: string
+  withoutCodeBlocksAndUrls: string
+  withoutMath: (singleDollarTextMath?: boolean) => string
+}
 
 export interface PreprocessParagraphAnalysis {
   codeBlockRanges: TextRange[]
   content: string
+  formattingMarkers: FormattingMarkerAnalysis
   inlineCodeRanges: TextRange[]
   isFullyCodeBlock: boolean
   startIndex: number
@@ -29,10 +45,65 @@ export interface PreprocessAnalysis {
 
 const analysisCache = new WeakMap<PreprocessContext, PreprocessAnalysis>()
 
+class CachedFormattingMarkerAnalysis implements FormattingMarkerAnalysis {
+  private cachedMaskedContent?: string
+  private cachedSingleAsteriskMarkers?: string
+  private cachedSingleUnderscoreMarkers?: string
+  private cachedWithoutCodeBlocksAndUrls?: string
+  private cachedWithoutMath?: string
+  private cachedWithoutSingleDollarMath?: string
+
+  constructor(private readonly paragraph: CachedParagraphAnalysis) {}
+
+  get maskedContent(): string {
+    if (this.cachedMaskedContent === undefined) {
+      const withoutInlineCodeMarkers = maskInlineCodeMarkdownMarkers(
+        this.paragraph.content,
+        this.paragraph.inlineCodeRanges,
+      )
+      const withoutThematicBreakMarkers = maskThematicBreakMarkers(withoutInlineCodeMarkers)
+      const withoutInvalidAsterisks = maskInvalidAsteriskMarkers(withoutThematicBreakMarkers)
+      this.cachedMaskedContent = maskInvalidUnderscoreMarkers(withoutInvalidAsterisks)
+    }
+    return this.cachedMaskedContent
+  }
+
+  get singleAsteriskMarkers(): string {
+    this.cachedSingleAsteriskMarkers ??= maskPairedMarkerRuns(this.maskedContent, '*')
+    return this.cachedSingleAsteriskMarkers
+  }
+
+  get singleUnderscoreMarkers(): string {
+    this.cachedSingleUnderscoreMarkers ??= maskPairedMarkerRuns(this.maskedContent, '_')
+    return this.cachedSingleUnderscoreMarkers
+  }
+
+  get withoutCodeBlocksAndUrls(): string {
+    this.cachedWithoutCodeBlocksAndUrls ??= removeUrlsFromText(
+      this.maskedContent.replace(codeBlockPattern, ''),
+    )
+    return this.cachedWithoutCodeBlocksAndUrls
+  }
+
+  withoutMath(singleDollarTextMath = false): string {
+    if (singleDollarTextMath) {
+      this.cachedWithoutSingleDollarMath ??= removeMathBlocksFromText(
+        this.withoutCodeBlocksAndUrls,
+        { singleDollarTextMath: true },
+      )
+      return this.cachedWithoutSingleDollarMath
+    }
+
+    this.cachedWithoutMath ??= removeMathBlocksFromText(this.withoutCodeBlocksAndUrls)
+    return this.cachedWithoutMath
+  }
+}
+
 class CachedParagraphAnalysis implements PreprocessParagraphAnalysis {
   private cachedCodeBlockRanges?: TextRange[]
   private cachedInlineCodeRanges?: TextRange[]
   readonly content: string
+  readonly formattingMarkers: FormattingMarkerAnalysis
   readonly startIndex: number
   readonly startOffset: number
 
@@ -42,6 +113,7 @@ class CachedParagraphAnalysis implements PreprocessParagraphAnalysis {
     this.startOffset = this.startIndex === 0
       ? 0
       : lines.slice(0, this.startIndex).join('\n').length + 1
+    this.formattingMarkers = new CachedFormattingMarkerAnalysis(this)
   }
 
   get codeBlockRanges(): TextRange[] {

--- a/packages/markmend/core/src/preprocess/delete.ts
+++ b/packages/markmend/core/src/preprocess/delete.ts
@@ -1,13 +1,11 @@
 import type { PreprocessContext } from '../types'
+import { getPreprocessAnalysis } from './context'
 import { codeBlockPattern, doubleTildePattern } from './pattern'
 import {
-  calculateParagraphOffset,
   findClosedCodeBlockRanges,
   findInlineCodeRanges,
-  getLastParagraphWithIndex,
   hideBareFormattingMarker,
   isEscapedCharacter,
-  isInsideUnclosedCodeBlock,
   isPositionInRanges,
   isWithinHtmlTag,
   isWithinLinkOrImageUrl,
@@ -40,21 +38,34 @@ import {
  */
 export function fixDelete(
   content: string,
-  options?: Pick<PreprocessContext, 'hideBareFormattingMarkers'>,
+  options?: PreprocessContext,
 ): string {
-  // Don't process if we're inside a code block (unclosed)
-  if (isInsideUnclosedCodeBlock(content))
+  if (!content.includes('~'))
     return content
 
-  const hiddenBareMarker = hideBareFormattingMarker(content, ['~', '~~'])
+  const analysis = getPreprocessAnalysis(content, options)
+  // Don't process if we're inside a code block (unclosed)
+  if (analysis.hasUnclosedCodeBlock)
+    return content
+
+  const hiddenBareMarker = hideBareFormattingMarker(
+    content,
+    ['~', '~~'],
+    analysis.getLastParagraph().content,
+  )
   if (hiddenBareMarker !== undefined)
     return options?.hideBareFormattingMarkers === false ? content : hiddenBareMarker
 
   // Find the last paragraph (after the last blank line)
   // A blank line is defined as a line with only whitespace
-  const { lastParagraph, startIndex: paragraphStartIndex } = getLastParagraphWithIndex(content)
-  const codeBlockRanges = findClosedCodeBlockRanges(lastParagraph)
-  const inlineCodeRanges = findInlineCodeRanges(lastParagraph, codeBlockRanges)
+  const paragraph = analysis.getLastParagraph()
+  const {
+    content: lastParagraph,
+    inlineCodeRanges,
+    startIndex: paragraphStartIndex,
+  } = paragraph
+  if (paragraph.isFullyCodeBlock)
+    return content
 
   // Remove code blocks and protect inline code / escaped tildes.
   const lastParagraphWithoutInlineCodeMarkers = maskInlineCodeMarkdownMarkers(lastParagraph, inlineCodeRanges)
@@ -106,7 +117,6 @@ export function fixDelete(
   // 2. There's actual content after the last ~~ (not just `~~` alone)
   if (count % 2 === 1) {
     // Find the last ~~ in original lastParagraph, skipping code blocks
-    const lines = content.split('\n')
     let actualLastTildePos = -1
     let inCodeBlock = false
     for (let i = 0; i < lastParagraph.length - 1; i++) {
@@ -134,8 +144,7 @@ export function fixDelete(
     if (actualLastTildePos === -1) {
       return content
     }
-    const paragraphOffset = calculateParagraphOffset(paragraphStartIndex, lines)
-    const absoluteLastTildePos = paragraphOffset + actualLastTildePos
+    const absoluteLastTildePos = paragraph.startOffset + actualLastTildePos
 
     // Check if the tilde is in math block, link/image URL, or HTML tag
     if (isWithinMathBlock(content, absoluteLastTildePos) || isWithinLinkOrImageUrl(content, absoluteLastTildePos) || isWithinHtmlTag(content, absoluteLastTildePos)) {

--- a/packages/markmend/core/src/preprocess/emphasis.ts
+++ b/packages/markmend/core/src/preprocess/emphasis.ts
@@ -1,16 +1,12 @@
 import type { PreprocessContext } from '../types'
+import { getPreprocessAnalysis } from './context'
 import {
   codeBlockPattern,
   singleAsteriskPattern,
   singleUnderscorePattern,
 } from './pattern'
 import {
-  calculateParagraphOffset,
-  findClosedCodeBlockRanges,
-  findInlineCodeRanges,
-  getLastParagraphWithIndex,
   hideBareFormattingMarker,
-  isInsideUnclosedCodeBlock,
   isPositionInRanges,
   isWithinHtmlTag,
   isWithinLinkOrImageUrl,
@@ -32,22 +28,35 @@ import {
  */
 export function fixEmphasis(
   content: string,
-  options?: Pick<PreprocessContext, 'hideBareFormattingMarkers'>,
+  options?: PreprocessContext,
 ): string {
+  if (!content.includes('*') && !content.includes('_'))
+    return content
+
+  const analysis = getPreprocessAnalysis(content, options)
   // Don't process if we're inside a code block (unclosed)
-  if (isInsideUnclosedCodeBlock(content)) {
+  if (analysis.hasUnclosedCodeBlock) {
     return content
   }
 
-  const hiddenBareMarker = hideBareFormattingMarker(content, ['*', '_'])
+  const hiddenBareMarker = hideBareFormattingMarker(
+    content,
+    ['*', '_'],
+    analysis.getLastParagraph().content,
+  )
   if (hiddenBareMarker !== undefined)
     return options?.hideBareFormattingMarkers === false ? content : hiddenBareMarker
 
   // Find the last paragraph
-  const lines = content.split('\n')
-  const { lastParagraph, startIndex: paragraphStartIndex } = getLastParagraphWithIndex(content)
-  const codeBlockRanges = findClosedCodeBlockRanges(lastParagraph)
-  const inlineCodeRanges = findInlineCodeRanges(lastParagraph, codeBlockRanges)
+  const paragraph = analysis.getLastParagraph()
+  const {
+    codeBlockRanges,
+    content: lastParagraph,
+    inlineCodeRanges,
+    startOffset: paragraphOffset,
+  } = paragraph
+  if (paragraph.isFullyCodeBlock)
+    return content
 
   // Remove code blocks and mask Markdown markers inside inline code to avoid
   // treating code content as incomplete emphasis.
@@ -81,7 +90,6 @@ export function fixEmphasis(
   if (asteriskCount % 2 === 1) {
     // Find the last * in the original lastParagraph, but skip those in URLs
     // We need to find the position in the original text, not in the URL-removed text
-    const paragraphOffset = calculateParagraphOffset(paragraphStartIndex, lines)
     let lastStarPos = -1
 
     // Search backwards in the original lastParagraph to find the last * that's not in a URL
@@ -123,7 +131,6 @@ export function fixEmphasis(
   // Check underscore
   if (underscoreCount % 2 === 1) {
     // Find the last _ in the original lastParagraph, but skip those in URLs
-    const paragraphOffset = calculateParagraphOffset(paragraphStartIndex, lines)
     let lastUnderscorePos = -1
 
     // Search backwards in the original lastParagraph to find the last _ that's not in a URL

--- a/packages/markmend/core/src/preprocess/emphasis.ts
+++ b/packages/markmend/core/src/preprocess/emphasis.ts
@@ -1,7 +1,6 @@
 import type { PreprocessContext } from '../types'
 import { getPreprocessAnalysis } from './context'
 import {
-  codeBlockPattern,
   singleAsteriskPattern,
   singleUnderscorePattern,
 } from './pattern'
@@ -11,14 +10,24 @@ import {
   isWithinHtmlTag,
   isWithinLinkOrImageUrl,
   isWithinMathBlock,
-  maskInlineCodeMarkdownMarkers,
-  maskInvalidAsteriskMarkers,
-  maskInvalidUnderscoreMarkers,
   maskPairedMarkerRuns,
-  maskThematicBreakMarkers,
-  removeUrlsFromText,
   shouldIgnoreUnderscoreMarker,
 } from './utils'
+
+function hasOddMarkerRun(content: string, marker: '*' | '_'): boolean {
+  for (let index = content.indexOf(marker); index !== -1;) {
+    const runStart = index
+    while (content[index] === marker)
+      index += 1
+
+    if ((index - runStart) % 2 === 1)
+      return true
+
+    index = content.indexOf(marker, index)
+  }
+
+  return false
+}
 
 /**
  * Fix unclosed emphasis (* or _) syntax in streaming markdown
@@ -47,6 +56,9 @@ export function fixEmphasis(
   if (hiddenBareMarker !== undefined)
     return options?.hideBareFormattingMarkers === false ? content : hiddenBareMarker
 
+  if (!hasOddMarkerRun(content, '*') && !hasOddMarkerRun(content, '_'))
+    return content
+
   // Find the last paragraph
   const paragraph = analysis.getLastParagraph()
   const {
@@ -60,25 +72,23 @@ export function fixEmphasis(
 
   // Remove code blocks and mask Markdown markers inside inline code to avoid
   // treating code content as incomplete emphasis.
-  const lastParagraphWithoutInlineCodeMarkers = maskInlineCodeMarkdownMarkers(lastParagraph, inlineCodeRanges)
-  const lastParagraphWithoutThematicBreakMarkers = maskThematicBreakMarkers(lastParagraphWithoutInlineCodeMarkers)
-  const lastParagraphWithoutInvalidAsterisks = maskInvalidAsteriskMarkers(lastParagraphWithoutThematicBreakMarkers)
-  const lastParagraphWithoutInvalidMarkers = maskInvalidUnderscoreMarkers(lastParagraphWithoutInvalidAsterisks)
-  const sourceSingleAsteriskMarkers = maskPairedMarkerRuns(lastParagraphWithoutInvalidMarkers, '*')
-  const sourceSingleUnderscoreMarkers = maskPairedMarkerRuns(lastParagraphWithoutInvalidMarkers, '_')
-  const lastParagraphWithoutCodeBlocks = lastParagraphWithoutInvalidMarkers.replace(codeBlockPattern, '')
-  // Remove URLs to avoid counting markdown syntax inside URLs (URLs may contain _, *, ~)
-  const lastParagraphWithoutCodeBlocksAndUrls = removeUrlsFromText(lastParagraphWithoutCodeBlocks)
-  const lastParagraphForMarkerCounting = lastParagraphWithoutCodeBlocksAndUrls
+  const formattingMarkers = paragraph.formattingMarkers
+  const sourceSingleAsteriskMarkers = formattingMarkers.singleAsteriskMarkers
+  const sourceSingleUnderscoreMarkers = formattingMarkers.singleUnderscoreMarkers
+  const lastParagraphForMarkerCounting = formattingMarkers.withoutCodeBlocksAndUrls
 
   // Check asterisk emphasis first (original behavior)
   // Mask complete pairs while preserving the source offsets of odd runs.
-  const withoutDoubleAsterisk = maskPairedMarkerRuns(lastParagraphForMarkerCounting, '*')
+  const withoutDoubleAsterisk = lastParagraphForMarkerCounting === formattingMarkers.maskedContent
+    ? sourceSingleAsteriskMarkers
+    : maskPairedMarkerRuns(lastParagraphForMarkerCounting, '*')
   const asteriskMatches = withoutDoubleAsterisk.match(singleAsteriskPattern)
   const asteriskCount = asteriskMatches ? asteriskMatches.length : 0
 
   // Check underscore emphasis
-  const withoutDoubleUnderscore = maskPairedMarkerRuns(lastParagraphForMarkerCounting, '_')
+  const withoutDoubleUnderscore = lastParagraphForMarkerCounting === formattingMarkers.maskedContent
+    ? sourceSingleUnderscoreMarkers
+    : maskPairedMarkerRuns(lastParagraphForMarkerCounting, '_')
   const underscoreMatches = withoutDoubleUnderscore.match(singleUnderscorePattern)
   const underscoreCount = underscoreMatches ? underscoreMatches.length : 0
 

--- a/packages/markmend/core/src/preprocess/footnote.ts
+++ b/packages/markmend/core/src/preprocess/footnote.ts
@@ -1,4 +1,6 @@
+import type { PreprocessContext } from '../types'
 import type { TextRange } from './utils'
+import { getPreprocessAnalysis } from './context'
 import {
   codeBlockPattern,
   footnoteDefLabelPattern,
@@ -13,7 +15,6 @@ import {
   findClosedCodeBlockRanges,
   findInlineCodeRanges,
   getLastParagraphWithIndex,
-  isInsideUnclosedCodeBlock,
   isPositionInRanges,
 
 } from './utils'
@@ -179,8 +180,11 @@ function collectCompleteReferences(
  * fixFootnote('```\n[^1]\n```\n\nText [^1]')
  * // Code block content is ignored, only processes Text [^1]
  */
-export function fixFootnote(content: string): string {
-  if (isInsideUnclosedCodeBlock(content)) {
+export function fixFootnote(content: string, preprocessContext?: PreprocessContext): string {
+  if (!content.includes('[^'))
+    return content
+
+  if (getPreprocessAnalysis(content, preprocessContext).hasUnclosedCodeBlock) {
     return content
   }
 

--- a/packages/markmend/core/src/preprocess/html.ts
+++ b/packages/markmend/core/src/preprocess/html.ts
@@ -1,7 +1,6 @@
+import type { PreprocessContext } from '../types'
+import { getPreprocessAnalysis } from './context'
 import {
-  findClosedCodeBlockRanges,
-  findInlineCodeRanges,
-  isInsideUnclosedCodeBlock,
   isPositionInRanges,
 } from './utils'
 
@@ -33,8 +32,12 @@ function isUnclosedHtmlFragment(fragment: string): boolean {
  * This prevents incomplete HTML from being emitted as plain text before the
  * parser can recognize it as an HTML node.
  */
-export function fixHtml(content: string): string {
-  if (!content || isInsideUnclosedCodeBlock(content))
+export function fixHtml(content: string, context?: PreprocessContext): string {
+  if (!content.includes('<'))
+    return content
+
+  const analysis = getPreprocessAnalysis(content, context)
+  if (analysis.hasUnclosedCodeBlock)
     return content
 
   const trailingWhitespace = content.match(trailingWhitespacePattern)?.[0] ?? ''
@@ -54,12 +57,10 @@ export function fixHtml(content: string): string {
   if (!isUnclosedHtmlFragment(fragment))
     return content
 
-  const codeBlockRanges = findClosedCodeBlockRanges(content)
-  if (isPositionInRanges(fragmentStart, codeBlockRanges))
+  if (isPositionInRanges(fragmentStart, analysis.codeBlockRanges))
     return content
 
-  const inlineCodeRanges = findInlineCodeRanges(content, codeBlockRanges)
-  if (isPositionInRanges(fragmentStart, inlineCodeRanges))
+  if (isPositionInRanges(fragmentStart, analysis.inlineCodeRanges))
     return content
 
   const beforeFragment = content.slice(0, fragmentStart).replace(trailingLineWhitespacePattern, '')

--- a/packages/markmend/core/src/preprocess/index.ts
+++ b/packages/markmend/core/src/preprocess/index.ts
@@ -2,6 +2,7 @@ import type { PreprocessContext, PreprocessStep, PreprocessStepName, PreprocessS
 import { flow } from '../utils'
 import { fixCode } from './code'
 import { fixComparisonOperators } from './comparison-operators'
+import { createPreprocessContext } from './context'
 import { fixDelete } from './delete'
 import { fixEmphasis } from './emphasis'
 import { fixFootnote } from './footnote'
@@ -15,6 +16,7 @@ import { fixTable } from './table'
 import { fixTaskList } from './task-list'
 import { parseMarkdownIntoBlocks, preprocessLaTeX } from './vendored'
 
+export * from './context'
 export * from './pattern'
 
 function proprocessContent(content: string): string {
@@ -63,9 +65,10 @@ export function preprocess(
   options?: PreprocessContext,
   steps: PreprocessSteps = {},
 ): string {
+  const context = createPreprocessContext(options)
   return DEFAULT_PREPROCESS_STEP_NAMES.reduce((result, name) => {
     const step = steps[name] ?? DEFAULT_PREPROCESS_STEPS[name]
-    return step(result, options)
+    return step(result, context)
   }, content)
 }
 

--- a/packages/markmend/core/src/preprocess/inline-math.ts
+++ b/packages/markmend/core/src/preprocess/inline-math.ts
@@ -1,5 +1,6 @@
+import type { PreprocessContext } from '../types'
+import { getPreprocessAnalysis } from './context'
 import { codeBlockPattern, doubleDollarPattern, inlineCodePattern } from './pattern'
-import { calculateParagraphOffset, getLastParagraphWithIndex, isInsideUnclosedCodeBlock } from './utils'
 
 /**
  * Fix unclosed inline math ($$) syntax in streaming markdown
@@ -29,19 +30,23 @@ import { calculateParagraphOffset, getLastParagraphWithIndex, isInsideUnclosedCo
  * fixInlineMath('$$\n')
  * // Returns: '$$\n' (no completion, this is block math)
  */
-export function fixInlineMath(content: string): string {
+export function fixInlineMath(content: string, context?: PreprocessContext): string {
   // Handle bare single $ first
   if (content === '$') {
     return ''
   }
 
+  if (!content.includes('$'))
+    return content
+
   // Don't process if we're inside a code block (unclosed)
-  if (isInsideUnclosedCodeBlock(content))
+  const analysis = getPreprocessAnalysis(content, context)
+  if (analysis.hasUnclosedCodeBlock)
     return content
 
   // Find the last paragraph (after the last blank line)
-  const lines = content.split('\n')
-  const { lastParagraph, startIndex: paragraphStartIndex } = getLastParagraphWithIndex(content)
+  const paragraph = analysis.getLastParagraph()
+  const lastParagraph = paragraph.content
 
   // Remove code blocks and inline code from the last paragraph to avoid counting $$ inside them
   let withoutCodeBlocks = lastParagraph.replace(codeBlockPattern, '')
@@ -90,8 +95,7 @@ export function fixInlineMath(content: string): string {
 
       // Complete inline math - LaTeX content should not be treated as markdown
       if (shouldRemoveTrailingDollar) {
-        const offset = calculateParagraphOffset(paragraphStartIndex, lines)
-        const actualLastDollarPos = offset + lastDollarPos
+        const actualLastDollarPos = paragraph.startOffset + lastDollarPos
         const contentBeforeMath = content.substring(0, actualLastDollarPos + 2)
         const contentAfterMath = lastParagraph.substring(lastDollarPos + 2, lastParagraph.length - 1)
         return `${contentBeforeMath}${contentAfterMath}$$`
@@ -100,8 +104,7 @@ export function fixInlineMath(content: string): string {
     }
     else {
       // Remove the trailing $$ and any trailing whitespace
-      const offset = calculateParagraphOffset(paragraphStartIndex, lines)
-      const actualLastDollarPos = offset + lastDollarPos
+      const actualLastDollarPos = paragraph.startOffset + lastDollarPos
       return content.slice(0, actualLastDollarPos).trimEnd()
     }
   }

--- a/packages/markmend/core/src/preprocess/link.ts
+++ b/packages/markmend/core/src/preprocess/link.ts
@@ -1,5 +1,7 @@
+import type { PreprocessContext } from '../types'
+import { getPreprocessAnalysis } from './context'
 import { codeBlockPattern, incompleteBracketPattern, incompleteLinkTextPattern, standaloneBracketPattern } from './pattern'
-import { findLastNonEmptyLineIndex, getLastParagraphWithIndex, isEscapedCharacter, isInsideUnclosedCodeBlock } from './utils'
+import { findLastNonEmptyLineIndex, isEscapedCharacter } from './utils'
 
 function hasTrailingIncompleteLinkUrl(content: string): boolean {
   const urlStart = content.lastIndexOf('](')
@@ -70,15 +72,23 @@ function hasTrailingIncompleteLinkUrl(content: string): boolean {
  * // Returns: 'Text '
  * // Removes trailing standalone bracket and trailing newline
  */
-export function fixLink(content: string): string {
+export function fixLink(content: string, context?: PreprocessContext): string {
+  if (!content.includes('['))
+    return content
+
+  const analysis = getPreprocessAnalysis(content, context)
   // Don't process if we're inside a code block (unclosed)
-  if (isInsideUnclosedCodeBlock(content)) {
+  if (analysis.hasUnclosedCodeBlock) {
     return content
   }
 
+  if (analysis.isFullyCodeBlock)
+    return content
+
   // Find the last paragraph (after the last blank line)
-  const lines = content.split('\n')
-  const { lastParagraph } = getLastParagraphWithIndex(content)
+  const { lines } = analysis
+  const paragraph = analysis.getLastParagraph()
+  const lastParagraph = paragraph.content
 
   // Remove code blocks from the last paragraph to avoid processing links inside them
   const lastParagraphWithoutCodeBlocks = lastParagraph.replace(codeBlockPattern, '')

--- a/packages/markmend/core/src/preprocess/math.ts
+++ b/packages/markmend/core/src/preprocess/math.ts
@@ -1,4 +1,5 @@
-import { isInsideUnclosedCodeBlock } from './utils'
+import type { PreprocessContext } from '../types'
+import { getPreprocessAnalysis } from './context'
 
 /**
  * Fix unclosed block math ($$) syntax in streaming markdown
@@ -22,13 +23,17 @@ import { isInsideUnclosedCodeBlock } from './utils'
  * fixMath('$$\nE = mc^2\n$$')
  * // Returns: '$$\nE = mc^2\n$$' (no change)
  */
-export function fixMath(content: string): string {
+export function fixMath(content: string, context?: PreprocessContext): string {
+  if (!content.includes('$'))
+    return content
+
+  const analysis = getPreprocessAnalysis(content, context)
   // Don't process if we're inside a code block (unclosed)
-  if (isInsideUnclosedCodeBlock(content)) {
+  if (analysis.hasUnclosedCodeBlock) {
     return content
   }
 
-  const lines = content.split('\n')
+  const { lines } = analysis
   let inCodeBlock = false
   const blockMathDelimiters: number[] = [] // Store indices of $$ delimiters on separate lines
 

--- a/packages/markmend/core/src/preprocess/strong.ts
+++ b/packages/markmend/core/src/preprocess/strong.ts
@@ -1,7 +1,6 @@
 import type { PreprocessContext } from '../types'
 import { getPreprocessAnalysis } from './context'
 import {
-  codeBlockPattern,
   doubleAsteriskPattern,
   doubleUnderscorePattern,
   singleAsteriskPattern,
@@ -15,12 +14,7 @@ import {
   isWithinHtmlTag,
   isWithinLinkOrImageUrl,
   isWithinMathBlock,
-  maskInlineCodeMarkdownMarkers,
-  maskInvalidAsteriskMarkers,
   maskInvalidUnderscoreMarkers,
-  maskThematicBreakMarkers,
-  removeMathBlocksFromText,
-  removeUrlsFromText,
   shouldIgnoreUnderscoreMarker,
 } from './utils'
 
@@ -84,17 +78,17 @@ export function fixStrong(
   if (paragraph.isFullyCodeBlock)
     return content
 
+  if (!lastParagraph.includes('**') && !lastParagraph.includes('__'))
+    return content
+
   // Remove code blocks and mask Markdown markers inside inline code to avoid
   // treating code content as incomplete strong emphasis.
-  const lastParagraphWithoutInlineCodeMarkers = maskInlineCodeMarkdownMarkers(lastParagraph, inlineCodeRanges)
-  const lastParagraphWithoutThematicBreakMarkers = maskThematicBreakMarkers(lastParagraphWithoutInlineCodeMarkers)
-  const lastParagraphWithoutInvalidAsterisks = maskInvalidAsteriskMarkers(lastParagraphWithoutThematicBreakMarkers)
-  const lastParagraphWithoutInvalidMarkers = maskInvalidUnderscoreMarkers(lastParagraphWithoutInvalidAsterisks)
-  const lastParagraphWithoutCodeBlocks = lastParagraphWithoutInvalidMarkers.replace(codeBlockPattern, '')
-  // Remove URLs to avoid counting markdown syntax inside URLs (URLs may contain _, *, ~)
-  const lastParagraphWithoutCodeBlocksAndUrls = removeUrlsFromText(lastParagraphWithoutCodeBlocks)
-  // Remove math blocks to avoid counting markdown syntax inside math (math may contain **, __, etc.)
-  const lastParagraphWithoutCodeBlocksAndUrlsAndMath = removeMathBlocksFromText(lastParagraphWithoutCodeBlocksAndUrls, options)
+  const formattingMarkers = paragraph.formattingMarkers
+  const lastParagraphWithoutInvalidMarkers = formattingMarkers.maskedContent
+  // Remove code blocks, URLs, and math to avoid counting their Markdown-like markers.
+  const lastParagraphWithoutCodeBlocksAndUrlsAndMath = formattingMarkers.withoutMath(
+    options?.singleDollarTextMath,
+  )
   const lastParagraphForMarkerCounting = lastParagraphWithoutCodeBlocksAndUrlsAndMath
 
   // Check if content ends with a single * or _ (not ** or __)
@@ -232,10 +226,10 @@ export function fixStrong(
     analysis = getPreprocessAnalysis(content, options)
     // Recalculate after removal. Again, skip any trailing empty line so we
     // still operate on the actual last non-empty paragraph.
-    const newLastParagraph = analysis.getLastParagraph(true).content
-    const newLastParagraphWithoutCodeBlocks = maskInlineCodeMarkdownMarkers(newLastParagraph).replace(codeBlockPattern, '')
-    const newLastParagraphWithoutCodeBlocksAndUrls = removeUrlsFromText(newLastParagraphWithoutCodeBlocks)
-    const newLastParagraphWithoutCodeBlocksAndUrlsAndMath = removeMathBlocksFromText(newLastParagraphWithoutCodeBlocksAndUrls, options)
+    const newParagraph = analysis.getLastParagraph(true)
+    const newLastParagraphWithoutCodeBlocksAndUrlsAndMath = newParagraph.formattingMarkers.withoutMath(
+      options?.singleDollarTextMath,
+    )
     const newAsteriskMatches = newLastParagraphWithoutCodeBlocksAndUrlsAndMath.match(doubleAsteriskPattern)
     const newAsteriskCount = newAsteriskMatches ? newAsteriskMatches.length : 0
     if (newAsteriskCount % 2 === 1) {
@@ -259,11 +253,10 @@ export function fixStrong(
     analysis = getPreprocessAnalysis(content, options)
     // Recalculate after removal. Again, skip any trailing empty line so we
     // still operate on the actual last non-empty paragraph.
-    const newLastParagraph = analysis.getLastParagraph(true).content
-    const newLastParagraphWithoutCodeBlocks = maskInlineCodeMarkdownMarkers(newLastParagraph).replace(codeBlockPattern, '')
-    const newLastParagraphWithoutCodeBlocksAndUrls = removeUrlsFromText(newLastParagraphWithoutCodeBlocks)
-    const newLastParagraphWithoutCodeBlocksAndUrlsAndMath = removeMathBlocksFromText(newLastParagraphWithoutCodeBlocksAndUrls, options)
-    const newLastParagraphForMarkerCounting = maskInvalidUnderscoreMarkers(newLastParagraphWithoutCodeBlocksAndUrlsAndMath)
+    const newParagraph = analysis.getLastParagraph(true)
+    const newLastParagraphForMarkerCounting = newParagraph.formattingMarkers.withoutMath(
+      options?.singleDollarTextMath,
+    )
     const newUnderscoreMatches = newLastParagraphForMarkerCounting.match(doubleUnderscorePattern)
     const newUnderscoreCount = newUnderscoreMatches ? newUnderscoreMatches.length : 0
     if (newUnderscoreCount % 2 === 1) {
@@ -320,10 +313,10 @@ export function fixStrong(
     // Check if there's also an unclosed single * that needs completion
     // But only if we didn't just remove a trailing single *
     if (!removedTrailingSingle) {
-      const currentLastParagraph = analysis.getLastParagraph(true).content
-      const currentLastParagraphWithoutCodeBlocks = maskInlineCodeMarkdownMarkers(currentLastParagraph).replace(codeBlockPattern, '')
-      const currentLastParagraphWithoutCodeBlocksAndUrls = removeUrlsFromText(currentLastParagraphWithoutCodeBlocks)
-      const currentLastParagraphWithoutCodeBlocksAndUrlsAndMath = removeMathBlocksFromText(currentLastParagraphWithoutCodeBlocksAndUrls, options)
+      const currentParagraph = analysis.getLastParagraph(true)
+      const currentLastParagraphWithoutCodeBlocksAndUrlsAndMath = currentParagraph.formattingMarkers.withoutMath(
+        options?.singleDollarTextMath,
+      )
       const withoutDoubleAsterisk = currentLastParagraphWithoutCodeBlocksAndUrlsAndMath.replace(doubleAsteriskPattern, '')
       const singleAsteriskMatches = withoutDoubleAsterisk.match(singleAsteriskPattern)
       const singleAsteriskCount = singleAsteriskMatches ? singleAsteriskMatches.length : 0
@@ -340,10 +333,10 @@ export function fixStrong(
     // Check if there's also an unclosed single _ that needs completion
     // But only if we didn't just remove a trailing single _
     if (!removedTrailingSingle) {
-      const currentLastParagraph = analysis.getLastParagraph().content
-      const currentLastParagraphWithoutCodeBlocks = maskInlineCodeMarkdownMarkers(currentLastParagraph).replace(codeBlockPattern, '')
-      const currentLastParagraphWithoutCodeBlocksAndUrls = removeUrlsFromText(currentLastParagraphWithoutCodeBlocks)
-      const currentLastParagraphWithoutCodeBlocksAndUrlsAndMath = removeMathBlocksFromText(currentLastParagraphWithoutCodeBlocksAndUrls, options)
+      const currentParagraph = analysis.getLastParagraph()
+      const currentLastParagraphWithoutCodeBlocksAndUrlsAndMath = currentParagraph.formattingMarkers.withoutMath(
+        options?.singleDollarTextMath,
+      )
       const withoutDoubleUnderscore = maskInvalidUnderscoreMarkers(currentLastParagraphWithoutCodeBlocksAndUrlsAndMath).replace(doubleUnderscorePattern, '')
       const singleUnderscoreMatches = withoutDoubleUnderscore.match(singleUnderscorePattern)
       const singleUnderscoreCount = singleUnderscoreMatches ? singleUnderscoreMatches.length : 0

--- a/packages/markmend/core/src/preprocess/strong.ts
+++ b/packages/markmend/core/src/preprocess/strong.ts
@@ -1,4 +1,5 @@
 import type { PreprocessContext } from '../types'
+import { getPreprocessAnalysis } from './context'
 import {
   codeBlockPattern,
   doubleAsteriskPattern,
@@ -9,12 +10,7 @@ import {
 } from './pattern'
 import {
   appendBeforeTrailingWhitespace,
-  calculateParagraphOffset,
-  findClosedCodeBlockRanges,
-  findInlineCodeRanges,
-  getLastParagraphWithIndex,
   hideBareFormattingMarker,
-  isInsideUnclosedCodeBlock,
   isPositionInRanges,
   isWithinHtmlTag,
   isWithinLinkOrImageUrl,
@@ -55,14 +51,22 @@ import {
  */
 export function fixStrong(
   content: string,
-  options?: Pick<PreprocessContext, 'hideBareFormattingMarkers' | 'singleDollarTextMath'>,
+  options?: PreprocessContext,
 ): string {
+  if (!content.includes('*') && !content.includes('_'))
+    return content
+
+  let analysis = getPreprocessAnalysis(content, options)
   // Don't process if we're inside a code block (unclosed)
-  if (isInsideUnclosedCodeBlock(content)) {
+  if (analysis.hasUnclosedCodeBlock) {
     return content
   }
 
-  const hiddenBareMarker = hideBareFormattingMarker(content, ['*', '**', '_', '__'])
+  const hiddenBareMarker = hideBareFormattingMarker(
+    content,
+    ['*', '**', '_', '__'],
+    analysis.getLastParagraph().content,
+  )
   if (hiddenBareMarker !== undefined)
     return options?.hideBareFormattingMarkers === false ? content : hiddenBareMarker
 
@@ -71,10 +75,14 @@ export function fixStrong(
   // (common with templated / indented content) doesn't appear as an
   // empty "last paragraph" and prevent us from fixing the real last
   // paragraph that contains the unclosed strong markers.
-  const lines = content.split('\n')
-  const { lastParagraph, startIndex: paragraphStartIndex } = getLastParagraphWithIndex(content, true)
-  const codeBlockRanges = findClosedCodeBlockRanges(lastParagraph)
-  const inlineCodeRanges = findInlineCodeRanges(lastParagraph, codeBlockRanges)
+  let paragraph = analysis.getLastParagraph(true)
+  const {
+    content: lastParagraph,
+    inlineCodeRanges,
+    startOffset: paragraphOffset,
+  } = paragraph
+  if (paragraph.isFullyCodeBlock)
+    return content
 
   // Remove code blocks and mask Markdown markers inside inline code to avoid
   // treating code content as incomplete strong emphasis.
@@ -136,7 +144,6 @@ export function fixStrong(
         i += 1 // Skip the second *
       }
     }
-    const paragraphOffset = calculateParagraphOffset(paragraphStartIndex, lines)
     const absoluteLastStarPos = paragraphOffset + actualLastStarPos
     if (actualLastStarPos >= 0) {
       let runEnd = actualLastStarPos
@@ -194,7 +201,6 @@ export function fixStrong(
         i += 1 // Skip the second _
       }
     }
-    const paragraphOffset = calculateParagraphOffset(paragraphStartIndex, lines)
     const absoluteLastUnderscorePos = paragraphOffset + actualLastUnderscorePos
 
     // Check if the underscore is in math block, link/image URL, or HTML tag
@@ -223,9 +229,10 @@ export function fixStrong(
     // Remove the trailing single * first
     content = content.slice(0, -1)
     removedTrailingSingle = true
+    analysis = getPreprocessAnalysis(content, options)
     // Recalculate after removal. Again, skip any trailing empty line so we
     // still operate on the actual last non-empty paragraph.
-    const { lastParagraph: newLastParagraph } = getLastParagraphWithIndex(content, true)
+    const newLastParagraph = analysis.getLastParagraph(true).content
     const newLastParagraphWithoutCodeBlocks = maskInlineCodeMarkdownMarkers(newLastParagraph).replace(codeBlockPattern, '')
     const newLastParagraphWithoutCodeBlocksAndUrls = removeUrlsFromText(newLastParagraphWithoutCodeBlocks)
     const newLastParagraphWithoutCodeBlocksAndUrlsAndMath = removeMathBlocksFromText(newLastParagraphWithoutCodeBlocksAndUrls, options)
@@ -249,9 +256,10 @@ export function fixStrong(
     // Remove the trailing single _ first
     content = content.slice(0, -1)
     removedTrailingSingle = true
+    analysis = getPreprocessAnalysis(content, options)
     // Recalculate after removal. Again, skip any trailing empty line so we
     // still operate on the actual last non-empty paragraph.
-    const { lastParagraph: newLastParagraph } = getLastParagraphWithIndex(content, true)
+    const newLastParagraph = analysis.getLastParagraph(true).content
     const newLastParagraphWithoutCodeBlocks = maskInlineCodeMarkdownMarkers(newLastParagraph).replace(codeBlockPattern, '')
     const newLastParagraphWithoutCodeBlocksAndUrls = removeUrlsFromText(newLastParagraphWithoutCodeBlocks)
     const newLastParagraphWithoutCodeBlocksAndUrlsAndMath = removeMathBlocksFromText(newLastParagraphWithoutCodeBlocksAndUrls, options)
@@ -282,10 +290,10 @@ export function fixStrong(
   }
 
   if (needsUnderscoreRemoval) {
-    const { lastParagraph: newLastParagraph, startIndex: newParagraphStartIndex } = getLastParagraphWithIndex(content)
+    paragraph = analysis.getLastParagraph()
+    const newLastParagraph = paragraph.content
     const lastUnderscorePos = newLastParagraph.lastIndexOf('__')
-    const paragraphOffset = calculateParagraphOffset(newParagraphStartIndex, content.split('\n'))
-    const absoluteLastUnderscorePos = paragraphOffset + lastUnderscorePos
+    const absoluteLastUnderscorePos = paragraph.startOffset + lastUnderscorePos
     let result = content.substring(0, absoluteLastUnderscorePos).trimEnd()
     if (trailingStandaloneDashWithNewlinesPattern.test(result)) {
       result = result.replace(trailingStandaloneDashWithNewlinesPattern, '$1')
@@ -312,7 +320,7 @@ export function fixStrong(
     // Check if there's also an unclosed single * that needs completion
     // But only if we didn't just remove a trailing single *
     if (!removedTrailingSingle) {
-      const { lastParagraph: currentLastParagraph } = getLastParagraphWithIndex(content, true)
+      const currentLastParagraph = analysis.getLastParagraph(true).content
       const currentLastParagraphWithoutCodeBlocks = maskInlineCodeMarkdownMarkers(currentLastParagraph).replace(codeBlockPattern, '')
       const currentLastParagraphWithoutCodeBlocksAndUrls = removeUrlsFromText(currentLastParagraphWithoutCodeBlocks)
       const currentLastParagraphWithoutCodeBlocksAndUrlsAndMath = removeMathBlocksFromText(currentLastParagraphWithoutCodeBlocksAndUrls, options)
@@ -332,7 +340,7 @@ export function fixStrong(
     // Check if there's also an unclosed single _ that needs completion
     // But only if we didn't just remove a trailing single _
     if (!removedTrailingSingle) {
-      const { lastParagraph: currentLastParagraph } = getLastParagraphWithIndex(content)
+      const currentLastParagraph = analysis.getLastParagraph().content
       const currentLastParagraphWithoutCodeBlocks = maskInlineCodeMarkdownMarkers(currentLastParagraph).replace(codeBlockPattern, '')
       const currentLastParagraphWithoutCodeBlocksAndUrls = removeUrlsFromText(currentLastParagraphWithoutCodeBlocks)
       const currentLastParagraphWithoutCodeBlocksAndUrlsAndMath = removeMathBlocksFromText(currentLastParagraphWithoutCodeBlocksAndUrls, options)

--- a/packages/markmend/core/src/preprocess/table.ts
+++ b/packages/markmend/core/src/preprocess/table.ts
@@ -1,9 +1,8 @@
+import type { PreprocessContext } from '../types'
+import { getPreprocessAnalysis } from './context'
 import { separatorPattern, tableRowPattern } from './pattern'
 import {
-  findClosedCodeBlockRanges,
-  getLastParagraphWithIndex,
   isEscapedCharacter,
-  isInsideUnclosedCodeBlock,
   isRangeOverlappingRanges,
 } from './utils'
 
@@ -76,16 +75,20 @@ function parseIncompleteSeparatorAlignments(row: string): TableAlignment[] | und
  * fixTable('| a | b |\n| --- | --- |')
  * // Returns: '| a | b |\n| --- | --- |' (no change, already complete)
  */
-export function fixTable(content: string): string {
+export function fixTable(content: string, context?: PreprocessContext): string {
+  if (!content.includes('|'))
+    return content
+
+  const analysis = getPreprocessAnalysis(content, context)
   // Don't process if we're inside a code block (unclosed)
-  if (isInsideUnclosedCodeBlock(content))
+  if (analysis.hasUnclosedCodeBlock)
     return content
 
   // Find all code block ranges to check if table is inside a closed code block
-  const codeBlockRanges = findClosedCodeBlockRanges(content)
+  const { codeBlockRanges } = analysis
 
   // Find the last paragraph (after the last blank line)
-  const { lastParagraph } = getLastParagraphWithIndex(content, true)
+  const lastParagraph = analysis.getLastParagraph(true).content
   const paragraphLines = lastParagraph.split('\n').filter(line => line.trim() !== '')
 
   // Check if any line in the last paragraph is a table header row

--- a/packages/markmend/core/src/preprocess/task-list.ts
+++ b/packages/markmend/core/src/preprocess/task-list.ts
@@ -1,8 +1,10 @@
+import type { PreprocessContext } from '../types'
+import { getPreprocessAnalysis } from './context'
 import {
   incompleteTaskListPattern,
   quoteIncompleteTaskListPattern,
 } from './pattern'
-import { findClosedCodeBlockRanges, isInsideUnclosedCodeBlock, isRangeOverlappingRanges } from './utils'
+import { isRangeOverlappingRanges } from './utils'
 
 const zeroWidthSpace = '\u200B'
 
@@ -56,17 +58,22 @@ function isPartialSetextUnderline(line: string): boolean {
  * fixTaskList('> **Note**: Here\'s a quote with tasks:\n\n> -')
  * // Returns: '> **Note**: Here\'s a quote with tasks:\n\n> -'
  */
-export function fixTaskList(content: string): string {
+export function fixTaskList(content: string, context?: PreprocessContext): string {
+  if (!content.includes('[') && !content.includes('\n'))
+    return content
+
+  const analysis = getPreprocessAnalysis(content, context)
   // Don't process if we're inside a code block (unclosed)
-  if (isInsideUnclosedCodeBlock(content)) {
+  if (analysis.hasUnclosedCodeBlock) {
     return content
   }
 
+  if (analysis.isFullyCodeBlock)
+    return content
+
   // Check if the last line is inside a code block
   // Find all code block ranges
-  const codeBlockRanges = findClosedCodeBlockRanges(content)
-
-  const lines = content.split('\n')
+  const { codeBlockRanges, lines } = analysis
 
   // Get the last line
   const lastLine = lines.at(-1)

--- a/packages/markmend/core/src/preprocess/utils.ts
+++ b/packages/markmend/core/src/preprocess/utils.ts
@@ -82,8 +82,8 @@ export function getLastParagraphWithIndex(
 export function hideBareFormattingMarker(
   content: string,
   markers: readonly string[],
+  lastParagraph = getLastParagraphWithIndex(content).lastParagraph,
 ): string | undefined {
-  const { lastParagraph } = getLastParagraphWithIndex(content)
   const containsOnlyMarkers = (value: string): boolean => {
     if (maskThematicBreakMarkers(value) !== value)
       return false

--- a/packages/markmend/core/src/preprocess/utils.ts
+++ b/packages/markmend/core/src/preprocess/utils.ts
@@ -85,11 +85,11 @@ export function hideBareFormattingMarker(
   lastParagraph = getLastParagraphWithIndex(content).lastParagraph,
 ): string | undefined {
   const containsOnlyMarkers = (value: string): boolean => {
-    if (maskThematicBreakMarkers(value) !== value)
+    const tokens = value.trim().split(/\s+/)
+    if (tokens.length === 0 || !tokens.every(token => markers.includes(token)))
       return false
 
-    const tokens = value.trim().split(/\s+/)
-    return tokens.length > 0 && tokens.every(token => markers.includes(token))
+    return maskThematicBreakMarkers(value) === value
   }
 
   if (containsOnlyMarkers(lastParagraph))
@@ -362,6 +362,9 @@ function isWhitespaceOrBoundary(content: string, index: number): boolean {
  * `*`, `_`, or `-` markers and up to three leading spaces.
  */
 export function maskThematicBreakMarkers(content: string): string {
+  if (!content.includes('*') && !content.includes('_') && !content.includes('-'))
+    return content
+
   return content.split('\n').map((line) => {
     const leadingWhitespace = line.match(/^ */)?.[0].length ?? 0
     if (leadingWhitespace > 3)
@@ -379,7 +382,10 @@ export function maskThematicBreakMarkers(content: string): string {
  * Mask asterisk runs that clearly cannot act as emphasis delimiters.
  */
 export function maskInvalidAsteriskMarkers(content: string): string {
-  const characters = content.split('')
+  if (!content.includes('*'))
+    return content
+
+  let characters: string[] | undefined
   let singleAsteriskCount = 0
   let inWordAsteriskChain = false
 
@@ -400,6 +406,7 @@ export function maskInvalidAsteriskMarkers(content: string): string {
         && isWhitespaceOrBoundary(content, index))
 
     if (cannotDelimit) {
+      characters ??= content.split('')
       for (let markerIndex = runStart; markerIndex < index; markerIndex += 1)
         characters[markerIndex] = ' '
       continue
@@ -426,11 +433,12 @@ export function maskInvalidAsteriskMarkers(content: string): string {
       inWordAsteriskChain = isInsideWord
     }
     else {
+      characters ??= content.split('')
       characters[singleMarkerIndex] = ' '
     }
   }
 
-  return characters.join('')
+  return characters?.join('') ?? content
 }
 
 /** Mask escaped Markdown markers while preserving string offsets. */
@@ -448,6 +456,9 @@ export function maskEscapedMarkdownMarkers(content: string, markers: string): st
  * This preserves offsets so a remaining marker can be mapped back to source.
  */
 export function maskPairedMarkerRuns(content: string, marker: '*' | '_'): string {
+  if (!content.includes(marker))
+    return content
+
   const characters = content.split('')
 
   for (let index = 0; index < content.length;) {
@@ -504,7 +515,10 @@ export function shouldIgnoreUnderscoreMarker(
  * Mask escaped and intraword underscore runs while preserving string offsets.
  */
 export function maskInvalidUnderscoreMarkers(content: string): string {
-  const characters = content.split('')
+  if (!content.includes('_'))
+    return content
+
+  let characters: string[] | undefined
 
   for (let index = 0; index < content.length;) {
     if (content[index] !== '_') {
@@ -518,12 +532,13 @@ export function maskInvalidUnderscoreMarkers(content: string): string {
 
     const runLength = index - runStart
     if (shouldIgnoreUnderscoreMarker(content, runStart, runLength)) {
+      characters ??= content.split('')
       for (let markerIndex = runStart; markerIndex < index; markerIndex += 1)
         characters[markerIndex] = ' '
     }
   }
 
-  return characters.join('')
+  return characters?.join('') ?? content
 }
 
 /**
@@ -674,26 +689,33 @@ export function isWithinHtmlTag(text: string, position: number): boolean {
  */
 export function removeUrlsFromText(text: string): string {
   // First, remove code blocks to avoid processing URLs inside them
-  const withoutCodeBlocks = text.replace(codeBlockPattern, '')
+  const withoutCodeBlocks = text.includes('```')
+    ? text.replace(codeBlockPattern, '')
+    : text
 
   // Remove HTML tags (including their attributes which may contain URLs)
   // This handles cases like <file url="http://example.com/path_with_underscore">
-  let result = withoutCodeBlocks.replace(htmlTagPattern, '')
+  let result = withoutCodeBlocks.includes('<')
+    ? withoutCodeBlocks.replace(htmlTagPattern, '')
+    : withoutCodeBlocks
 
   // Remove complete link/image URLs: [text](url) or ![alt](url)
   // Replace the URL part with empty string, keep the [text] or ![alt] part
-  result = result.replace(linkImagePattern, (match) => {
-    return match.replace(linkImageUrlSuffixPattern, ']()')
-  })
+  if (result.includes('](')) {
+    result = result.replace(linkImagePattern, (match) => {
+      return match.replace(linkImageUrlSuffixPattern, ']()')
+    })
 
-  // Remove incomplete link/image URLs: [text](url or ![alt](url
-  // Replace the incomplete URL part with empty string
-  result = result.replace(incompleteLinkImageUrlPattern, (match) => {
-    return match.replace(incompleteLinkImageUrlSuffixPattern, '](')
-  })
+    // Remove incomplete link/image URLs: [text](url or ![alt](url
+    // Replace the incomplete URL part with empty string
+    result = result.replace(incompleteLinkImageUrlPattern, (match) => {
+      return match.replace(incompleteLinkImageUrlSuffixPattern, '](')
+    })
+  }
 
   // Remove standalone URLs as their path/query may contain Markdown markers.
-  result = result.replace(standaloneUrlPattern, '')
+  if (result.includes('://'))
+    result = result.replace(standaloneUrlPattern, '')
 
   return result
 }
@@ -710,6 +732,9 @@ export function removeMathBlocksFromText(
   text: string,
   options?: Pick<PreprocessContext, 'singleDollarTextMath'>,
 ): string {
+  if (!text.includes('$'))
+    return text
+
   const singleDollarEnabled = options?.singleDollarTextMath === true
   let result = text
   let i = 0

--- a/packages/markmend/core/src/preprocess/vendored/parse-blocks.ts
+++ b/packages/markmend/core/src/preprocess/vendored/parse-blocks.ts
@@ -2,153 +2,156 @@
 
 import { Lexer } from 'marked'
 
-// Regex patterns moved to top level for performance
-const footnoteReferencePattern = /\[\^[^\]\s]{1,200}\](?!:)/
-const footnoteDefinitionPattern = /\[\^[^\]\s]{1,200}\]:/
-const closingTagPattern = /<\/(\w+)>/
-const openingTagPattern = /<(\w+)[\s>]/
+const footnoteReferencePattern = /\[\^[\w-]{1,200}\](?!:)/
+const footnoteDefinitionPattern = /\[\^[\w-]{1,200}\]:/
+const openingTagPattern = /<([a-z][\w:-]*)[\s>/]/i
 
-// Helper function to check if string starts with $$
-function startsWithDoubleDollar(str: string): boolean {
-  let i = 0
-  // Skip leading whitespace
-  while (
-    i < str.length
-    && (str[i] === ' ' || str[i] === '\t' || str[i] === '\n' || str[i] === '\r')
-  ) {
-    i += 1
-  }
-  return i + 1 < str.length && str[i] === '$' && str[i + 1] === '$'
+const voidElements = new Set([
+  'area',
+  'base',
+  'br',
+  'col',
+  'embed',
+  'hr',
+  'img',
+  'input',
+  'link',
+  'meta',
+  'param',
+  'source',
+  'track',
+  'wbr',
+])
+
+const openTagPatternCache = new Map<string, RegExp>()
+const closeTagPatternCache = new Map<string, RegExp>()
+
+function getOpenTagPattern(tagName: string): RegExp {
+  const normalizedTag = tagName.toLowerCase()
+  const cached = openTagPatternCache.get(normalizedTag)
+  if (cached)
+    return cached
+
+  const pattern = new RegExp(`<${normalizedTag}(?=[\\s>/])[^>]*>`, 'gi')
+  openTagPatternCache.set(normalizedTag, pattern)
+  return pattern
 }
 
-// Helper function to check if string ends with $$
-function endsWithDoubleDollar(str: string): boolean {
-  let i = str.length - 1
-  // Skip trailing whitespace
-  while (
-    i >= 0
-    && (str[i] === ' ' || str[i] === '\t' || str[i] === '\n' || str[i] === '\r')
-  ) {
-    i -= 1
-  }
-  return i >= 1 && str[i] === '$' && str[i - 1] === '$'
+function getCloseTagPattern(tagName: string): RegExp {
+  const normalizedTag = tagName.toLowerCase()
+  const cached = closeTagPatternCache.get(normalizedTag)
+  if (cached)
+    return cached
+
+  const pattern = new RegExp(`</${normalizedTag}(?=[\\s>])[^>]*>`, 'gi')
+  closeTagPatternCache.set(normalizedTag, pattern)
+  return pattern
 }
 
-// Helper function to count $$ occurrences
-function countDoubleDollars(str: string): number {
+function countNonSelfClosingOpenTags(block: string, tagName: string): number {
+  if (voidElements.has(tagName.toLowerCase()))
+    return 0
+
+  const matches = block.match(getOpenTagPattern(tagName))
+  if (!matches)
+    return 0
+
   let count = 0
-  for (let i = 0; i < str.length - 1; i += 1) {
-    if (str[i] === '$' && str[i + 1] === '$') {
+  for (const match of matches) {
+    if (!match.trimEnd().endsWith('/>'))
       count += 1
-      i += 1 // Skip next character
+  }
+  return count
+}
+
+function countClosingTags(block: string, tagName: string): number {
+  return block.match(getCloseTagPattern(tagName))?.length ?? 0
+}
+
+function countDoubleDollars(value: string): number {
+  let count = 0
+  for (let index = 0; index < value.length - 1; index += 1) {
+    if (value[index] === '$' && value[index + 1] === '$') {
+      count += 1
+      index += 1
     }
   }
   return count
 }
 
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: "Complex parsing logic that handles multiple markdown edge cases"
 export function parseMarkdownIntoBlocks(markdown: string): string[] {
-  // Check if the markdown contains footnotes (references or definitions)
-  // Footnote references: [^1], [^label], etc.
-  // Footnote definitions: [^1]: text, [^label]: text, etc.
-  // Use atomic groups or possessive quantifiers to prevent backtracking
-  const hasFootnoteReference = footnoteReferencePattern.test(markdown)
-  const hasFootnoteDefinition = footnoteDefinitionPattern.test(markdown)
-
-  // If footnotes are present, return the entire document as a single block
-  // This ensures footnote references and definitions remain in the same mdast tree
-  if (hasFootnoteReference || hasFootnoteDefinition) {
+  if (
+    footnoteReferencePattern.test(markdown)
+    || footnoteDefinitionPattern.test(markdown)
+  ) {
     return [markdown]
   }
 
   const tokens = Lexer.lex(markdown, { gfm: true })
-
-  // Post-process to merge consecutive blocks that belong together
   const mergedBlocks: string[] = []
-  const htmlStack: string[] = [] // Track opening HTML tags
+  const htmlStack: string[] = []
+  let previousTokenWasCode = false
+  let mergeFollowingSpaceIntoHtml = false
 
   for (const token of tokens) {
     const currentBlock = token.raw
-    const mergedBlocksLen = mergedBlocks.length
+    const mergedBlocksLength = mergedBlocks.length
 
-    // Check if we're inside an HTML block
-    if (htmlStack.length > 0) {
-      // We're inside an HTML block, merge with the previous block
-      mergedBlocks[mergedBlocksLen - 1] += currentBlock
-
-      // Check if this token closes an HTML tag
-      if (token.type === 'html') {
-        const closingTagMatch = currentBlock.match(closingTagPattern)
-        if (closingTagMatch) {
-          const closingTag = closingTagMatch[1]
-          // Check if this closes the most recent opening tag
-          if (htmlStack.at(-1) === closingTag) {
-            htmlStack.pop()
-          }
-        }
+    if (mergeFollowingSpaceIntoHtml) {
+      mergeFollowingSpaceIntoHtml = false
+      if (token.type === 'space' && mergedBlocksLength > 0) {
+        mergedBlocks[mergedBlocksLength - 1] += currentBlock
+        continue
       }
+    }
+
+    if (htmlStack.length > 0) {
+      mergedBlocks[mergedBlocksLength - 1] += currentBlock
+
+      const trackedTag = htmlStack.at(-1)!
+      const newOpenTags = countNonSelfClosingOpenTags(currentBlock, trackedTag)
+      const newCloseTags = countClosingTags(currentBlock, trackedTag)
+
+      for (let index = 0; index < newOpenTags; index += 1)
+        htmlStack.push(trackedTag)
+
+      for (let index = 0; index < newCloseTags; index += 1) {
+        if (htmlStack.at(-1) === trackedTag)
+          htmlStack.pop()
+      }
+      mergeFollowingSpaceIntoHtml = htmlStack.length === 0
       continue
     }
 
-    // Check if this is an opening HTML block tag
     if (token.type === 'html' && token.block) {
       const openingTagMatch = currentBlock.match(openingTagPattern)
-      if (openingTagMatch && openingTagMatch[1]) {
+      if (openingTagMatch?.[1]) {
         const tagName = openingTagMatch[1]
-        // Check if this is a self-closing tag or if there's a closing tag in the same block
-        const hasClosingTag = currentBlock.includes(`</${tagName}>`)
-        if (!hasClosingTag) {
-          // This is an opening tag without a closing tag in the same block
+        const openTags = countNonSelfClosingOpenTags(currentBlock, tagName)
+        const closeTags = countClosingTags(currentBlock, tagName)
+        if (openTags > closeTags)
           htmlStack.push(tagName)
-        }
       }
     }
 
-    // Optimize trim operations by checking characters directly
-    const trimmedBlock = currentBlock.trim()
-
-    // Math block merging logic (existing)
-    // Check if this is a standalone $$ that might be a closing delimiter
-    if (trimmedBlock === '$$' && mergedBlocksLen > 0) {
-      const previousBlock = mergedBlocks[mergedBlocksLen - 1]
-      if (!previousBlock)
-        continue
-
-      // Check if the previous block starts with $$ but doesn't end with $$
-      const prevStartsWith$$ = startsWithDoubleDollar(previousBlock)
-      const prevDollarCount = countDoubleDollars(previousBlock)
-
-      // If previous block has odd number of $$ and starts with $$, merge them
-      if (prevStartsWith$$ && prevDollarCount % 2 === 1) {
-        mergedBlocks[mergedBlocksLen - 1] = previousBlock + currentBlock
-        continue
-      }
-    }
-
-    // Check if current block ends with $$ and previous block started with $$ but didn't close
-    if (mergedBlocksLen > 0 && endsWithDoubleDollar(currentBlock)) {
-      const previousBlock = mergedBlocks[mergedBlocksLen - 1]
-      if (!previousBlock)
-        continue
-
-      const prevStartsWith$$ = startsWithDoubleDollar(previousBlock)
-      const prevDollarCount = countDoubleDollars(previousBlock)
-      const currDollarCount = countDoubleDollars(currentBlock)
-
-      // If previous block has unclosed math (odd $$) and current block ends with $$
-      // AND current block doesn't start with $$, it's likely a continuation
-      if (
-        prevStartsWith$$
-        && prevDollarCount % 2 === 1
-        && !startsWithDoubleDollar(currentBlock)
-        && currDollarCount === 1
-      ) {
-        mergedBlocks[mergedBlocksLen - 1] = previousBlock + currentBlock
+    if (mergedBlocksLength > 0 && !previousTokenWasCode) {
+      const previousBlock = mergedBlocks[mergedBlocksLength - 1]!
+      if (countDoubleDollars(previousBlock) % 2 === 1) {
+        mergedBlocks[mergedBlocksLength - 1] = previousBlock + currentBlock
         continue
       }
     }
 
     mergedBlocks.push(currentBlock)
+
+    mergeFollowingSpaceIntoHtml = (
+      token.type === 'html'
+      && Boolean(token.block)
+      && htmlStack.length === 0
+    )
+
+    if (token.type !== 'space')
+      previousTokenWasCode = token.type === 'code'
   }
 
   return mergedBlocks

--- a/pncat.config.ts
+++ b/pncat.config.ts
@@ -4,6 +4,11 @@ import { dependencies } from './playground/nuxt/package.json'
 const RUNTIME_DEPS = ['vue', '@vueuse/core', '@floating-ui/dom']
 
 export default defineConfig({
+  excludeDepFields: [
+    'overrides',
+    'pnpm.overrides',
+    'resolutions',
+  ],
   exclude: [
     'shiki',
     'mermaid',
@@ -12,8 +17,22 @@ export default defineConfig({
   ],
   catalogRules: mergeCatalogRules([
     {
+      name: 'benchmark',
+      match: [
+        'comark',
+        'react',
+        'react-dom',
+        'remark-gfm',
+        'remark-parse',
+        'remend',
+        'streamdown',
+        'unified',
+      ],
+      priority: -10,
+    },
+    {
       name: 'parser',
-      match: [/marked/, /mdast-/, /micromark-/],
+      match: [/marked/, /mdast-/, /micromark-/, 'parse5', 'sanitize-html'],
       priority: 0,
     },
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,31 @@ settings:
   excludeLinksFromLockfile: false
 
 catalogs:
+  benchmark:
+    comark:
+      specifier: 0.6.2
+      version: 0.6.2
+    react:
+      specifier: 18.3.1
+      version: 18.3.1
+    react-dom:
+      specifier: 18.3.1
+      version: 18.3.1
+    remark-gfm:
+      specifier: 4.0.1
+      version: 4.0.1
+    remark-parse:
+      specifier: 11.0.0
+      version: 11.0.0
+    remend:
+      specifier: 1.3.1
+      version: 1.3.1
+    streamdown:
+      specifier: 2.6.0
+      version: 2.6.0
+    unified:
+      specifier: 11.0.5
+      version: 11.0.5
   build:
     '@tsdown/css':
       specifier: ^0.22.14
@@ -256,9 +281,6 @@ importers:
       bumpp:
         specifier: catalog:dev
         version: 12.1.1
-      comark:
-        specifier: 0.6.2
-        version: 0.6.2(beautiful-mermaid@1.1.3)(shiki@4.4.1)
       eslint:
         specifier: catalog:lint
         version: 10.8.0(jiti@2.7.0)(supports-color@10.2.2)
@@ -277,9 +299,6 @@ importers:
       pncat:
         specifier: catalog:dev
         version: 0.13.0
-      remend:
-        specifier: 1.3.1
-        version: 1.3.1
       simple-git-hooks:
         specifier: catalog:dev
         version: 2.13.1
@@ -320,6 +339,36 @@ importers:
         specifier: catalog:lint
         version: 3.3.9(typescript@6.0.3)
 
+  benchmark:
+    devDependencies:
+      comark:
+        specifier: catalog:benchmark
+        version: 0.6.2(beautiful-mermaid@1.1.3)(shiki@4.4.1)
+      react:
+        specifier: catalog:benchmark
+        version: 18.3.1
+      react-dom:
+        specifier: catalog:benchmark
+        version: 18.3.1(react@18.3.1)
+      remark-gfm:
+        specifier: catalog:benchmark
+        version: 4.0.1(supports-color@10.2.2)
+      remark-parse:
+        specifier: catalog:benchmark
+        version: 11.0.0(supports-color@10.2.2)
+      remend:
+        specifier: catalog:benchmark
+        version: 1.3.1
+      streamdown:
+        specifier: catalog:benchmark
+        version: 2.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@10.2.2)
+      unified:
+        specifier: catalog:benchmark
+        version: 11.0.5
+      vitest:
+        specifier: catalog:test
+        version: 4.1.10(@types/node@26.1.2)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.1)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(tsx@4.23.5)(yaml@2.9.0))
+
   docs:
     dependencies:
       '@vueuse/core':
@@ -334,7 +383,7 @@ importers:
     devDependencies:
       vitepress:
         specifier: catalog:docs
-        version: 1.6.4(@algolia/client-search@5.56.0)(@types/node@26.1.2)(change-case@5.4.4)(fuse.js@7.5.0)(lightningcss@1.33.0)(postcss@8.5.25)(search-insights@2.17.3)(terser@5.49.0)(typescript@6.0.3)
+        version: 1.6.4(@algolia/client-search@5.56.0)(@types/node@26.1.2)(change-case@5.4.4)(fuse.js@7.5.0)(lightningcss@1.33.0)(postcss@8.5.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(terser@5.49.0)(typescript@6.0.3)
       vitepress-plugin-llms:
         specifier: catalog:docs
         version: 1.13.4(supports-color@10.2.2)
@@ -2600,6 +2649,9 @@ packages:
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
 
+  '@types/estree-jsx@1.0.5':
+    resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
+
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
@@ -2644,6 +2696,9 @@ packages:
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
+  '@types/unist@2.0.11':
+    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
@@ -3749,6 +3804,9 @@ packages:
   character-entities@2.0.2:
     resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
 
+  character-reference-invalid@2.0.1:
+    resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
+
   chokidar@5.0.0:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
     engines: {node: '>= 20.19.0'}
@@ -4335,6 +4393,10 @@ packages:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
 
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
   entities@7.0.1:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
@@ -4638,6 +4700,9 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-util-is-identifier-name@3.0.0:
+    resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
+
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
@@ -4912,11 +4977,32 @@ packages:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
+  hast-util-from-parse5@8.0.3:
+    resolution: {integrity: sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==}
+
+  hast-util-parse-selector@4.0.0:
+    resolution: {integrity: sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==}
+
+  hast-util-raw@9.1.0:
+    resolution: {integrity: sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==}
+
+  hast-util-sanitize@5.0.2:
+    resolution: {integrity: sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==}
+
   hast-util-to-html@9.0.5:
     resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
 
+  hast-util-to-jsx-runtime@2.3.6:
+    resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
+
+  hast-util-to-parse5@8.0.1:
+    resolution: {integrity: sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==}
+
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
+  hastscript@9.0.1:
+    resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
 
   hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
@@ -4929,6 +5015,9 @@ packages:
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  html-url-attributes@3.0.1:
+    resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
@@ -5009,6 +5098,9 @@ packages:
     resolution: {integrity: sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
+  inline-style-parser@0.2.7:
+    resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
   internmap@1.0.1:
     resolution: {integrity: sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==}
 
@@ -5023,6 +5115,12 @@ packages:
   iron-webcrypto@1.2.1:
     resolution: {integrity: sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==}
 
+  is-alphabetical@2.0.1:
+    resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
+
+  is-alphanumerical@2.0.1:
+    resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
+
   is-builtin-module@5.0.0:
     resolution: {integrity: sha512-f4RqJKBUe5rQkJ2eJEJBXSticB3hGbN9j0yxxMQFqIW89Jp9WYFtzfTcRlstDKVUTRzSOTLKRfO9vIztenwtxA==}
     engines: {node: '>=18.20'}
@@ -5030,6 +5128,9 @@ packages:
   is-core-module@2.16.2:
     resolution: {integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==}
     engines: {node: '>= 0.4'}
+
+  is-decimal@2.0.1:
+    resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
 
   is-docker@3.0.0:
     resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
@@ -5051,6 +5152,9 @@ packages:
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
+
+  is-hexadecimal@2.0.1:
+    resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
 
   is-identifier@1.1.0:
     resolution: {integrity: sha512-NhOds0mDx9lJu+1lBRO0xbwFo5nobA7GCk/0e5xjr6+6XugX985+0OyGX35BNrTkPAsdLcIKg02HUQJOK8D8kw==}
@@ -5370,6 +5474,10 @@ packages:
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
+  loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
+
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
@@ -5430,6 +5538,11 @@ packages:
     engines: {node: '>= 20'}
     hasBin: true
 
+  marked@17.0.6:
+    resolution: {integrity: sha512-gB0gkNafnonOw0obSTEGZTT86IuhILt2Wfx0mWH/1Au83kybTayroZ/V6nS25mN7u8ASy+5fMhgB3XPNrOZdmA==}
+    engines: {node: '>= 20'}
+    hasBin: true
+
   marked@18.0.7:
     resolution: {integrity: sha512-iDVQ5ldaiKXn6b2JroX5kgRfmwgqolW7NpaEzTl1k/2Zh1njIEN9yniyLV/mOvWwtsE8OGgkjsCYvijuPk1dtA==}
     engines: {node: '>= 20'}
@@ -5464,6 +5577,15 @@ packages:
 
   mdast-util-math@3.0.0:
     resolution: {integrity: sha512-Tl9GBNeG/AhJnQM221bJR2HPvLOSnLE/T9cJI9tlc6zwQk2nPk/4f0cHkOdEixQPC/j8UtKDdITswvLAy1OZ1w==}
+
+  mdast-util-mdx-expression@2.0.1:
+    resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
+
+  mdast-util-mdx-jsx@3.2.0:
+    resolution: {integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==}
+
+  mdast-util-mdxjs-esm@2.0.1:
+    resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
 
   mdast-util-phrasing@4.1.0:
     resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
@@ -5960,6 +6082,9 @@ packages:
   package-manager-detector@1.8.0:
     resolution: {integrity: sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==}
 
+  parse-entities@4.0.2:
+    resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
+
   parse-gitignore@2.0.0:
     resolution: {integrity: sha512-RmVuCHWsfu0QPNW+mraxh/xjQVw/lhUCUru8Zni3Ctq3AoMhpDTq0OVdKS6iesd6Kqb7viCV3isAL43dciOSog==}
     engines: {node: '>=14'}
@@ -5972,6 +6097,9 @@ packages:
 
   parse-statements@1.0.11:
     resolution: {integrity: sha512-HlsyYdMBnbPQ9Jr/VgJ1YF4scnldvJpJxCVx6KgqPL4dxppsWrJHCIIxQXMJrqGnsRkNPATbeMJ8Yxu7JMsYcA==}
+
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
   parse5@8.0.1:
     resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
@@ -6326,6 +6454,15 @@ packages:
   rc9@3.0.1:
     resolution: {integrity: sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ==}
 
+  react-dom@18.3.1:
+    resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
+    peerDependencies:
+      react: ^18.3.1
+
+  react@18.3.1:
+    resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
+    engines: {node: '>=0.10.0'}
+
   readable-stream@2.3.8:
     resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
 
@@ -6373,11 +6510,26 @@ packages:
     resolution: {integrity: sha512-NgRBy2Nx/bE+9F27nVHnqcN5HjyLmecqsqx2PJHu3/IEtADD4WuxuXIVExD5PoSDFVrl78dOonfcOe5O+5nbzQ==}
     hasBin: true
 
+  rehype-harden@1.1.8:
+    resolution: {integrity: sha512-Qn7vR1xrf6fZCrkm9TDWi/AB4ylrHy+jqsNm1EHOAmbARYA6gsnVJBq/sdBh6kmT4NEZxH5vgIjrscefJAOXcw==}
+
+  rehype-raw@7.0.0:
+    resolution: {integrity: sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==}
+
+  rehype-sanitize@6.0.0:
+    resolution: {integrity: sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==}
+
   remark-frontmatter@5.0.0:
     resolution: {integrity: sha512-XTFYvNASMe5iPN0719nPrdItC9aU0ssC4v14mH1BCi1u0n1gAocqcujWUrByftZTbLhRtiKRyjYTSIOcr69UVQ==}
 
+  remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
   remark-parse@11.0.0:
     resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+
+  remark-rehype@11.1.2:
+    resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
 
   remark-stringify@11.0.0:
     resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
@@ -6513,6 +6665,9 @@ packages:
   sax@1.6.1:
     resolution: {integrity: sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==}
     engines: {node: '>=11.0.0'}
+
+  scheduler@0.23.2:
+    resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
   schema-utils@4.3.3:
     resolution: {integrity: sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==}
@@ -6675,6 +6830,12 @@ packages:
   std-env@4.2.0:
     resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
 
+  streamdown@2.6.0:
+    resolution: {integrity: sha512-nQZVUn4GvB2R5SAlDNph20iKZeW+RM4gv6G1H3ACypEnmQf8PgTHZ/1Ta2OACRwQ2coK7aW5AeIAa7Ls5zk+RA==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+
   streamx@2.28.0:
     resolution: {integrity: sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==}
 
@@ -6724,6 +6885,12 @@ packages:
 
   structured-clone-es@2.0.1:
     resolution: {integrity: sha512-10ZL5r77LhknxlP1FBiCW+VdnuWOEFLdSS2SKtjyEV+L4qP1hUEIMIZW94LC3jKxRmT/Dj7KkD1mqh/IY6lhKQ==}
+
+  style-to-js@1.1.21:
+    resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
+
+  style-to-object@1.0.14:
+    resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
 
   stylehacks@8.0.1:
     resolution: {integrity: sha512-Gv095oTD0N+BdJALNFDsxZpETHZLTxbOl5RyIO7y6VAE6sR3z0MnV3Nix7N0IATNldNTrkvSASp2KR1Yt526HA==}
@@ -7237,6 +7404,9 @@ packages:
     resolution: {integrity: sha512-w2Eo8LSIIoW7qxNBzT7/17k+bh8plXo7G3dHjEIDqPlnluhzaxr9JX8F28VSYEtDvc1/a3WBDih6xNUZseebXg==}
     engines: {node: '>=18.12.0'}
 
+  vfile-location@5.0.3:
+    resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
+
   vfile-message@4.0.3:
     resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
 
@@ -7495,6 +7665,9 @@ packages:
   watchpack@2.5.2:
     resolution: {integrity: sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg==}
     engines: {node: '>=10.13.0'}
+
+  web-namespaces@2.0.1:
+    resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
   web-worker@1.5.0:
     resolution: {integrity: sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==}
@@ -8081,9 +8254,9 @@ snapshots:
 
   '@docsearch/css@3.8.2': {}
 
-  '@docsearch/js@3.8.2(@algolia/client-search@5.56.0)(search-insights@2.17.3)':
+  '@docsearch/js@3.8.2(@algolia/client-search@5.56.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)':
     dependencies:
-      '@docsearch/react': 3.8.2(@algolia/client-search@5.56.0)(search-insights@2.17.3)
+      '@docsearch/react': 3.8.2(@algolia/client-search@5.56.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)
       preact: 10.29.8
     transitivePeerDependencies:
       - '@algolia/client-search'
@@ -8093,13 +8266,15 @@ snapshots:
       - react-dom
       - search-insights
 
-  '@docsearch/react@3.8.2(@algolia/client-search@5.56.0)(search-insights@2.17.3)':
+  '@docsearch/react@3.8.2(@algolia/client-search@5.56.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)':
     dependencies:
       '@algolia/autocomplete-core': 1.17.7(@algolia/client-search@5.56.0)(algoliasearch@5.56.0)(search-insights@2.17.3)
       '@algolia/autocomplete-preset-algolia': 1.17.7(@algolia/client-search@5.56.0)(algoliasearch@5.56.0)
       '@docsearch/css': 3.8.2
       algoliasearch: 5.56.0
     optionalDependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
       search-insights: 2.17.3
     transitivePeerDependencies:
       - '@algolia/client-search'
@@ -9755,6 +9930,10 @@ snapshots:
 
   '@types/esrecurse@4.3.1': {}
 
+  '@types/estree-jsx@1.0.5':
+    dependencies:
+      '@types/estree': 1.0.9
+
   '@types/estree@1.0.9': {}
 
   '@types/geojson@7946.0.16': {}
@@ -9796,6 +9975,8 @@ snapshots:
 
   '@types/trusted-types@2.0.7':
     optional: true
+
+  '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
 
@@ -11060,6 +11241,8 @@ snapshots:
 
   character-entities@2.0.2: {}
 
+  character-reference-invalid@2.0.1: {}
+
   chokidar@5.0.0:
     dependencies:
       readdirp: 5.0.0
@@ -11637,6 +11820,8 @@ snapshots:
 
   entities@4.5.0: {}
 
+  entities@6.0.1: {}
+
   entities@7.0.1: {}
 
   entities@8.0.0: {}
@@ -12072,6 +12257,8 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-util-is-identifier-name@3.0.0: {}
+
   estree-walker@2.0.2: {}
 
   estree-walker@3.0.3:
@@ -12333,6 +12520,43 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hast-util-from-parse5@8.0.3:
+    dependencies:
+      '@types/hast': 3.0.5
+      '@types/unist': 3.0.3
+      devlop: 1.1.0
+      hastscript: 9.0.1
+      property-information: 7.2.0
+      vfile: 6.0.3
+      vfile-location: 5.0.3
+      web-namespaces: 2.0.1
+
+  hast-util-parse-selector@4.0.0:
+    dependencies:
+      '@types/hast': 3.0.5
+
+  hast-util-raw@9.1.0:
+    dependencies:
+      '@types/hast': 3.0.5
+      '@types/unist': 3.0.3
+      '@ungap/structured-clone': 1.3.3
+      hast-util-from-parse5: 8.0.3
+      hast-util-to-parse5: 8.0.1
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.1
+      parse5: 7.3.0
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+      web-namespaces: 2.0.1
+      zwitch: 2.0.4
+
+  hast-util-sanitize@5.0.2:
+    dependencies:
+      '@types/hast': 3.0.5
+      '@ungap/structured-clone': 1.3.3
+      unist-util-position: 5.0.0
+
   hast-util-to-html@9.0.5:
     dependencies:
       '@types/hast': 3.0.5
@@ -12347,9 +12571,47 @@ snapshots:
       stringify-entities: 4.0.4
       zwitch: 2.0.4
 
+  hast-util-to-jsx-runtime@2.3.6(supports-color@10.2.2):
+    dependencies:
+      '@types/estree': 1.0.9
+      '@types/hast': 3.0.5
+      '@types/unist': 3.0.3
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      hast-util-whitespace: 3.0.0
+      mdast-util-mdx-expression: 2.0.1(supports-color@10.2.2)
+      mdast-util-mdx-jsx: 3.2.0(supports-color@10.2.2)
+      mdast-util-mdxjs-esm: 2.0.1(supports-color@10.2.2)
+      property-information: 7.2.0
+      space-separated-tokens: 2.0.2
+      style-to-js: 1.1.21
+      unist-util-position: 5.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  hast-util-to-parse5@8.0.1:
+    dependencies:
+      '@types/hast': 3.0.5
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      property-information: 7.2.0
+      space-separated-tokens: 2.0.2
+      web-namespaces: 2.0.1
+      zwitch: 2.0.4
+
   hast-util-whitespace@3.0.0:
     dependencies:
       '@types/hast': 3.0.5
+
+  hastscript@9.0.1:
+    dependencies:
+      '@types/hast': 3.0.5
+      comma-separated-tokens: 2.0.3
+      hast-util-parse-selector: 4.0.0
+      property-information: 7.2.0
+      space-separated-tokens: 2.0.2
 
   hookable@5.5.3: {}
 
@@ -12358,6 +12620,8 @@ snapshots:
   html-entities@2.6.0: {}
 
   html-escaper@2.0.2: {}
+
+  html-url-attributes@3.0.1: {}
 
   html-void-elements@3.0.0: {}
 
@@ -12444,6 +12708,8 @@ snapshots:
 
   ini@4.1.1: {}
 
+  inline-style-parser@0.2.7: {}
+
   internmap@1.0.1: {}
 
   internmap@2.0.3: {}
@@ -12462,6 +12728,13 @@ snapshots:
 
   iron-webcrypto@1.2.1: {}
 
+  is-alphabetical@2.0.1: {}
+
+  is-alphanumerical@2.0.1:
+    dependencies:
+      is-alphabetical: 2.0.1
+      is-decimal: 2.0.1
+
   is-builtin-module@5.0.0:
     dependencies:
       builtin-modules: 5.3.0
@@ -12469,6 +12742,8 @@ snapshots:
   is-core-module@2.16.2:
     dependencies:
       hasown: 2.0.4
+
+  is-decimal@2.0.1: {}
 
   is-docker@3.0.0: {}
 
@@ -12481,6 +12756,8 @@ snapshots:
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
+
+  is-hexadecimal@2.0.1: {}
 
   is-identifier@1.1.0:
     dependencies:
@@ -12753,6 +13030,10 @@ snapshots:
 
   longest-streak@3.1.0: {}
 
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
+
   lru-cache@10.4.3: {}
 
   lru-cache@11.5.2: {}
@@ -12827,6 +13108,8 @@ snapshots:
   markdown-title@1.0.2: {}
 
   marked@16.4.2: {}
+
+  marked@17.0.6: {}
 
   marked@18.0.7: {}
 
@@ -12931,6 +13214,45 @@ snapshots:
       mdast-util-from-markdown: 2.0.3(supports-color@10.2.2)
       mdast-util-to-markdown: 2.1.2
       unist-util-remove-position: 5.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-expression@2.0.1(supports-color@10.2.2):
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3(supports-color@10.2.2)
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-jsx@3.2.0(supports-color@10.2.2):
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3(supports-color@10.2.2)
+      mdast-util-to-markdown: 2.1.2
+      parse-entities: 4.0.2
+      stringify-entities: 4.0.4
+      unist-util-stringify-position: 4.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdxjs-esm@2.0.1(supports-color@10.2.2):
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3(supports-color@10.2.2)
+      mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
@@ -13801,6 +14123,16 @@ snapshots:
 
   package-manager-detector@1.8.0: {}
 
+  parse-entities@4.0.2:
+    dependencies:
+      '@types/unist': 2.0.11
+      character-entities-legacy: 3.0.0
+      character-reference-invalid: 2.0.1
+      decode-named-character-reference: 1.3.0
+      is-alphanumerical: 2.0.1
+      is-decimal: 2.0.1
+      is-hexadecimal: 2.0.1
+
   parse-gitignore@2.0.0: {}
 
   parse-imports-exports@0.2.4:
@@ -13810,6 +14142,10 @@ snapshots:
   parse-srcset@1.0.2: {}
 
   parse-statements@1.0.11: {}
+
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
 
   parse5@8.0.1:
     dependencies:
@@ -14115,6 +14451,16 @@ snapshots:
       defu: 6.1.7
       destr: 2.0.5
 
+  react-dom@18.3.1(react@18.3.1):
+    dependencies:
+      loose-envify: 1.4.0
+      react: 18.3.1
+      scheduler: 0.23.2
+
+  react@18.3.1:
+    dependencies:
+      loose-envify: 1.4.0
+
   readable-stream@2.3.8:
     dependencies:
       core-util-is: 1.0.3
@@ -14170,11 +14516,37 @@ snapshots:
     dependencies:
       jsesc: 3.1.0
 
+  rehype-harden@1.1.8:
+    dependencies:
+      unist-util-visit: 5.1.0
+
+  rehype-raw@7.0.0:
+    dependencies:
+      '@types/hast': 3.0.5
+      hast-util-raw: 9.1.0
+      vfile: 6.0.3
+
+  rehype-sanitize@6.0.0:
+    dependencies:
+      '@types/hast': 3.0.5
+      hast-util-sanitize: 5.0.2
+
   remark-frontmatter@5.0.0(supports-color@10.2.2):
     dependencies:
       '@types/mdast': 4.0.4
       mdast-util-frontmatter: 2.0.1(supports-color@10.2.2)
       micromark-extension-frontmatter: 2.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-gfm@4.0.1(supports-color@10.2.2):
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0(supports-color@10.2.2)
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0(supports-color@10.2.2)
+      remark-stringify: 11.0.0
       unified: 11.0.5
     transitivePeerDependencies:
       - supports-color
@@ -14187,6 +14559,14 @@ snapshots:
       unified: 11.0.5
     transitivePeerDependencies:
       - supports-color
+
+  remark-rehype@11.1.2:
+    dependencies:
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      mdast-util-to-hast: 13.2.1
+      unified: 11.0.5
+      vfile: 6.0.3
 
   remark-stringify@11.0.0:
     dependencies:
@@ -14355,6 +14735,10 @@ snapshots:
 
   sax@1.6.1: {}
 
+  scheduler@0.23.2:
+    dependencies:
+      loose-envify: 1.4.0
+
   schema-utils@4.3.3:
     dependencies:
       '@types/json-schema': 7.0.15
@@ -14516,6 +14900,28 @@ snapshots:
 
   std-env@4.2.0: {}
 
+  streamdown@2.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@10.2.2):
+    dependencies:
+      clsx: 2.1.1
+      hast-util-to-jsx-runtime: 2.3.6(supports-color@10.2.2)
+      html-url-attributes: 3.0.1
+      marked: 17.0.6
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      rehype-harden: 1.1.8
+      rehype-raw: 7.0.0
+      rehype-sanitize: 6.0.0
+      remark-gfm: 4.0.1(supports-color@10.2.2)
+      remark-parse: 11.0.0(supports-color@10.2.2)
+      remark-rehype: 11.1.2
+      remend: 1.3.1
+      tailwind-merge: 3.6.0
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+      unist-util-visit-parents: 6.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   streamx@2.28.0:
     dependencies:
       events-universal: 1.0.1
@@ -14578,6 +14984,14 @@ snapshots:
       js-tokens: 10.0.0
 
   structured-clone-es@2.0.1: {}
+
+  style-to-js@1.1.21:
+    dependencies:
+      style-to-object: 1.0.14
+
+  style-to-object@1.0.14:
+    dependencies:
+      inline-style-parser: 0.2.7
 
   stylehacks@8.0.1(postcss@8.5.25):
     dependencies:
@@ -15123,6 +15537,11 @@ snapshots:
 
   verkit@0.3.1: {}
 
+  vfile-location@5.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile: 6.0.3
+
   vfile-message@4.0.3:
     dependencies:
       '@types/unist': 3.0.3
@@ -15251,10 +15670,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vitepress@1.6.4(@algolia/client-search@5.56.0)(@types/node@26.1.2)(change-case@5.4.4)(fuse.js@7.5.0)(lightningcss@1.33.0)(postcss@8.5.25)(search-insights@2.17.3)(terser@5.49.0)(typescript@6.0.3):
+  vitepress@1.6.4(@algolia/client-search@5.56.0)(@types/node@26.1.2)(change-case@5.4.4)(fuse.js@7.5.0)(lightningcss@1.33.0)(postcss@8.5.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(terser@5.49.0)(typescript@6.0.3):
     dependencies:
       '@docsearch/css': 3.8.2
-      '@docsearch/js': 3.8.2(@algolia/client-search@5.56.0)(search-insights@2.17.3)
+      '@docsearch/js': 3.8.2(@algolia/client-search@5.56.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)
       '@iconify-json/simple-icons': 1.2.93
       '@shikijs/core': 2.5.0
       '@shikijs/transformers': 2.5.0
@@ -15409,6 +15828,8 @@ snapshots:
   watchpack@2.5.2:
     dependencies:
       graceful-fs: 4.2.11
+
+  web-namespaces@2.0.1: {}
 
   web-worker@1.5.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -256,6 +256,9 @@ importers:
       bumpp:
         specifier: catalog:dev
         version: 12.1.1
+      comark:
+        specifier: 0.6.2
+        version: 0.6.2(beautiful-mermaid@1.1.3)(shiki@4.4.1)
       eslint:
         specifier: catalog:lint
         version: 10.8.0(jiti@2.7.0)(supports-color@10.2.2)
@@ -274,6 +277,9 @@ importers:
       pncat:
         specifier: catalog:dev
         version: 0.13.0
+      remend:
+        specifier: 1.3.1
+        version: 1.3.1
       simple-git-hooks:
         specifier: catalog:dev
         version: 2.13.1
@@ -3791,6 +3797,23 @@ packages:
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
 
+  comark@0.6.2:
+    resolution: {integrity: sha512-hlWa7KlGPfRxovQavnHZlLlTUKrfwE7/o4ewCY0FzqFtRvVT8VdslrumQwELIiK9utsurpoSWCBFj1yVMtDOtw==}
+    peerDependencies:
+      beautiful-mermaid: ^1.1.3
+      katex: ^0.17.0
+      rangi: ^2.2.0
+      shiki: ^4.3.1
+    peerDependenciesMeta:
+      beautiful-mermaid:
+        optional: true
+      katex:
+        optional: true
+      rangi:
+        optional: true
+      shiki:
+        optional: true
+
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
@@ -5135,6 +5158,10 @@ packages:
     resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
+  js-yaml@5.4.1:
+    resolution: {integrity: sha512-28R/k+NAjeuf7+CKlTxWZVExJGwVVLwY06DgEnOMz2gEpfNkDcD7QvyiVPT0xy0XXhU8vHsd4Ot42OOPdJG7dQ==}
+    hasBin: true
+
   jsdoc-type-pratt-parser@7.2.0:
     resolution: {integrity: sha512-dh140MMgjyg3JhJZY/+iEzW+NO5xR2gpbDFKHqotCmexElVntw7GjWjt511+C/Ef02RU5TKYrJo/Xlzk+OLaTw==}
     engines: {node: '>=20.0.0'}
@@ -5383,6 +5410,9 @@ packages:
 
   mark.js@8.11.1:
     resolution: {integrity: sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==}
+
+  markdown-exit@1.1.0-beta.2:
+    resolution: {integrity: sha512-8CzMGVlFZ4DEfnc8KU+4ycUW2SIOuiXqCHD7z51ecVEi/weyc0f2ylQbCm4KoKuVlTZSuMUMnWT0hTyquZ7anQ==}
 
   markdown-it@14.3.0:
     resolution: {integrity: sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==}
@@ -6354,6 +6384,9 @@ packages:
 
   remark@15.0.1:
     resolution: {integrity: sha512-Eht5w30ruCXgFmxVUSlNWQ9iiimq07URKeFS3hNc8cUWy1llX4KDWfyEDZRycMc+znsN9Ux5/tJ/BFdgdOwA3A==}
+
+  remend@1.3.1:
+    resolution: {integrity: sha512-N3DiY5qbRPoa5vkxn1oDLMyXOVTeo6Hp+XOj6SIqJAYUgLS0Q587gILPMom/qm86AQ/ZrcOdwEIzCz8V3J0nxQ==}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -11067,6 +11100,16 @@ snapshots:
 
   colorette@2.0.20: {}
 
+  comark@0.6.2(beautiful-mermaid@1.1.3)(shiki@4.4.1):
+    dependencies:
+      entities: 8.0.0
+      htmlparser2: 12.0.0
+      js-yaml: 5.4.1
+      markdown-exit: 1.1.0-beta.2
+    optionalDependencies:
+      beautiful-mermaid: 1.1.3
+      shiki: 4.4.1
+
   comma-separated-tokens@2.0.3: {}
 
   commander@10.0.1: {}
@@ -12530,6 +12573,10 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  js-yaml@5.4.1:
+    dependencies:
+      argparse: 2.0.1
+
   jsdoc-type-pratt-parser@7.2.0: {}
 
   jsdoc-type-pratt-parser@7.3.0: {}
@@ -12755,6 +12802,16 @@ snapshots:
       semver: 7.8.5
 
   mark.js@8.11.1: {}
+
+  markdown-exit@1.1.0-beta.2:
+    dependencies:
+      '@types/linkify-it': 5.0.0
+      '@types/mdurl': 2.0.0
+      entities: 7.0.1
+      linkify-it: 5.0.2
+      mdurl: 2.1.0
+      punycode.js: 2.3.1
+      uc.micro: 2.1.0
 
   markdown-it@14.3.0:
     dependencies:
@@ -14145,6 +14202,8 @@ snapshots:
       unified: 11.0.5
     transitivePeerDependencies:
       - supports-color
+
+  remend@1.3.1: {}
 
   require-directory@2.1.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,5 @@
 packages:
+  - benchmark
   - packages/*
   - packages/extensions/*
   - packages/markmend/*
@@ -7,7 +8,21 @@ packages:
 overrides:
   typescript: catalog:dev
   vue: catalog:frontend
+allowBuilds:
+  '@parcel/watcher': true
+  esbuild: true
+  simple-git-hooks: true
+  unrs-resolver: true
 catalogs:
+  benchmark:
+    comark: 0.6.2
+    react: 18.3.1
+    react-dom: 18.3.1
+    remark-gfm: 4.0.1
+    remark-parse: 11.0.0
+    remend: 1.3.1
+    streamdown: 2.6.0
+    unified: 11.0.5
   build:
     '@tsdown/css': ^0.22.14
     '@vitejs/plugin-vue': ^6.0.8
@@ -91,8 +106,3 @@ onlyBuiltDependencies:
   - simple-git-hooks
   - '@parcel/watcher'
   - unrs-resolver
-allowBuilds:
-  '@parcel/watcher': true
-  esbuild: true
-  simple-git-hooks: true
-  unrs-resolver: true

--- a/test/markmend/parser.test.ts
+++ b/test/markmend/parser.test.ts
@@ -377,6 +377,36 @@ describe('markdown-parser', () => {
     }
   })
 
+  it.each([
+    [
+      'nested HTML',
+      '# Stable\n\n<div>\n<div>\ninner\n</div>\n\nafter inner\n</div>\n\noutside',
+    ],
+    [
+      'custom HTML',
+      '# Stable\n\n<my-box>\ninside\n</my-box>\n\noutside',
+    ],
+    [
+      'math split across lexer tokens',
+      '# Stable\n\nBefore $$\nx\n=\ny\n$$\n\nafter',
+    ],
+    [
+      'regex-like text',
+      '# Stable\n\nPattern [^\\s+] example.\n\nNext paragraph.',
+    ],
+  ])('should preserve %s block boundaries while appending', (_, document) => {
+    const parser = new MarkdownAstParser({ mode: 'streaming' })
+
+    for (let end = 1; end <= document.length; end += 5) {
+      const content = document.slice(0, end)
+      const result = parser.parseMarkdown(content)
+      const freshResult = new MarkdownAstParser({ mode: 'streaming' })
+        .parseMarkdown(content)
+
+      expect(omitFalseLoading(result)).toEqual(omitFalseLoading(freshResult))
+    }
+  })
+
   it('should allow overriding a single preprocess step', () => {
     const html = vi.fn((content: string) => `${content}>`)
     const parser = new MarkdownAstParser({

--- a/test/markmend/parser.test.ts
+++ b/test/markmend/parser.test.ts
@@ -2,6 +2,11 @@ import type { ParsedNode, SyntaxTree } from '@markmend/ast'
 import { MarkdownAstParser } from '@markmend/ast'
 import { describe, expect, it, vi } from 'vitest'
 
+interface PositionableTestNode {
+  children?: PositionableTestNode[]
+  position?: unknown
+}
+
 function hasAnyLoading(nodes: ParsedNode[]): boolean {
   for (const node of nodes) {
     if (node.loading)
@@ -473,6 +478,36 @@ describe('markdown-parser', () => {
     parser.parseMarkdown('plain')
 
     expect(hooks).toEqual(['postnormalize', 'postprocess'])
+  })
+
+  it('should omit positions from the default normalized ast', () => {
+    const parser = new MarkdownAstParser({ mode: 'streaming' })
+    const result = parser.parseMarkdown('# Heading\n\n- [x] **completed** item')
+
+    const assertPositionless = (node: PositionableTestNode) => {
+      expect(node.position).toBeUndefined()
+      for (const child of node.children ?? [])
+        assertPositionless(child)
+    }
+
+    for (const ast of result.asts)
+      assertPositionless(ast)
+  })
+
+  it('should expose positions to a custom postnormalize hook', () => {
+    let rootPosition: SyntaxTree['position']
+    const parser = new MarkdownAstParser({
+      mode: 'streaming',
+      postnormalize: (data) => {
+        rootPosition = data.position
+        return data
+      },
+    })
+
+    const result = parser.parseMarkdown('plain')
+
+    expect(rootPosition).toBeDefined()
+    expect(result.asts[0]?.position).toBeDefined()
   })
 
   it('should skip postprocess when mode is static', () => {

--- a/test/markmend/parser.test.ts
+++ b/test/markmend/parser.test.ts
@@ -20,6 +20,15 @@ function getFirstNodeTag(ast: SyntaxTree): string | undefined {
   return node?.data?.tag
 }
 
+function omitFalseLoading<T>(value: T): T {
+  return JSON.parse(JSON.stringify(
+    value,
+    (key, nestedValue) => key === 'loading' && nestedValue === false
+      ? undefined
+      : nestedValue,
+  )) as T
+}
+
 describe('markdown-parser', () => {
   it('should mark only the last block tail text as loading in streaming mode', () => {
     const parser = new MarkdownAstParser({
@@ -233,6 +242,134 @@ describe('markdown-parser', () => {
     expect(preprocess).toHaveBeenCalledTimes(1)
     expect(parseMarkdownIntoBlocks).toHaveBeenCalledTimes(1)
     expect(result.contents[0]).toBe('normalized\n')
+  })
+
+  it('should only re-segment the changing tail for appended streaming content', () => {
+    const parser = new MarkdownAstParser({ mode: 'streaming' })
+    const initial = '# Stable title\n\nStable paragraph.\n\n- item one\n- item two'
+    const updated = `${initial}\n\n## Live response\n\nGrowing tail`
+
+    parser.parseMarkdown(initial)
+
+    const processor = (parser as unknown as {
+      processor: { parseMarkdownIntoBlocks: (content: string) => string[] }
+    }).processor
+    const split = vi.spyOn(processor, 'parseMarkdownIntoBlocks')
+    const result = parser.parseMarkdown(updated)
+    const freshResult = new MarkdownAstParser({ mode: 'streaming' }).parseMarkdown(updated)
+
+    expect(split).toHaveBeenCalledTimes(1)
+    expect(split.mock.calls[0]![0].length).toBeLessThan(updated.length)
+    expect(omitFalseLoading(result)).toEqual(omitFalseLoading(freshResult))
+  })
+
+  it('should fully re-segment content after a non-append edit', () => {
+    const parser = new MarkdownAstParser({ mode: 'streaming' })
+    const initial = '# Stable title\n\nOriginal paragraph.\n\nTail paragraph.'
+    const updated = '# Stable title\n\nEdited paragraph.\n\nTail paragraph.'
+
+    parser.parseMarkdown(initial)
+
+    const processor = (parser as unknown as {
+      processor: { parseMarkdownIntoBlocks: (content: string) => string[] }
+    }).processor
+    const split = vi.spyOn(processor, 'parseMarkdownIntoBlocks')
+
+    parser.parseMarkdown(updated)
+
+    expect(split).toHaveBeenCalledOnce()
+    expect(split).toHaveBeenCalledWith(updated)
+  })
+
+  it('should fully re-segment content when appended text introduces a footnote', () => {
+    const parser = new MarkdownAstParser({ mode: 'streaming' })
+    const initial = '# Stable title\n\nStable paragraph.'
+    const updated = `${initial}\n\nFootnote[^1]\n\n[^1]: Definition`
+
+    parser.parseMarkdown(initial)
+
+    const processor = (parser as unknown as {
+      processor: { parseMarkdownIntoBlocks: (content: string) => string[] }
+    }).processor
+    const split = vi.spyOn(processor, 'parseMarkdownIntoBlocks')
+    const result = parser.parseMarkdown(updated)
+
+    expect(split).toHaveBeenCalledOnce()
+    expect(split).toHaveBeenCalledWith(updated)
+    expect(result.asts).toHaveLength(1)
+  })
+
+  it('should preserve full parsing for custom block parsers', () => {
+    const parseMarkdownIntoBlocks = vi.fn((content: string) => [content])
+    const parser = new MarkdownAstParser({
+      mode: 'streaming',
+      parseMarkdownIntoBlocks,
+    })
+
+    parser.parseMarkdown('first')
+    parser.parseMarkdown('first append')
+
+    expect(parseMarkdownIntoBlocks).toHaveBeenCalledTimes(2)
+    expect(parseMarkdownIntoBlocks).toHaveBeenLastCalledWith('first append')
+  })
+
+  it.each([
+    ['setext heading', 'Paragraph', 'Paragraph\n---'],
+    ['fenced code', '```ts\nconst value = 1', '```ts\nconst value = 1\n```'],
+    ['math block', '$$\nx + y', '$$\nx + y\n$$'],
+    ['html block', '<div>\ncontent', '<div>\ncontent\n</div>'],
+  ])('should preserve %s parsing while appending', (_, firstTail, finalTail) => {
+    const prefix = '# Stable title\n\nStable paragraph.\n\n'
+    const parser = new MarkdownAstParser({ mode: 'streaming' })
+
+    parser.parseMarkdown(prefix + firstTail)
+    const result = parser.parseMarkdown(prefix + finalTail)
+    const freshResult = new MarkdownAstParser({ mode: 'streaming' })
+      .parseMarkdown(prefix + finalTail)
+
+    expect(omitFalseLoading(result)).toEqual(omitFalseLoading(freshResult))
+  })
+
+  it('should match fresh parsing across arbitrary streaming chunk boundaries', () => {
+    const document = [
+      '# Streaming document',
+      '',
+      'A paragraph with **bold**, *emphasis*, and [a link](https://example.com).',
+      '',
+      'Setext heading',
+      '---',
+      '',
+      '- first item',
+      '- second item',
+      '',
+      '> quoted text',
+      '',
+      '```ts',
+      'const value = 1',
+      '```',
+      '',
+      '$$',
+      'x + y',
+      '$$',
+      '',
+      '<div>',
+      'HTML content',
+      '</div>',
+    ].join('\n')
+    const parser = new MarkdownAstParser({ mode: 'streaming' })
+    const chunkEnds = new Set<number>()
+    for (let end = 1; end < document.length; end += 7)
+      chunkEnds.add(end)
+    chunkEnds.add(document.length)
+
+    for (const end of chunkEnds) {
+      const content = document.slice(0, end)
+      const result = parser.parseMarkdown(content)
+      const freshResult = new MarkdownAstParser({ mode: 'streaming' })
+        .parseMarkdown(content)
+
+      expect(omitFalseLoading(result)).toEqual(omitFalseLoading(freshResult))
+    }
   })
 
   it('should allow overriding a single preprocess step', () => {

--- a/test/markmend/preprocess/context.test.ts
+++ b/test/markmend/preprocess/context.test.ts
@@ -1,0 +1,46 @@
+import { createPreprocessContext, getPreprocessAnalysis } from '@markmend/core'
+import { describe, expect, it } from 'vitest'
+
+describe('preprocess context', () => {
+  it('reuses analysis for unchanged content', () => {
+    const context = createPreprocessContext()
+
+    expect(getPreprocessAnalysis('same', context))
+      .toBe(getPreprocessAnalysis('same', context))
+  })
+
+  it('invalidates analysis when content changes', () => {
+    const context = createPreprocessContext()
+    const initial = getPreprocessAnalysis('before', context)
+
+    expect(getPreprocessAnalysis('after', context)).not.toBe(initial)
+  })
+
+  it('does not share analysis between contexts', () => {
+    const first = createPreprocessContext()
+    const second = createPreprocessContext()
+
+    expect(getPreprocessAnalysis('same', first))
+      .not
+      .toBe(getPreprocessAnalysis('same', second))
+  })
+
+  it('does not mutate the supplied context', () => {
+    const supplied = { hideBareFormattingMarkers: false }
+    const context = createPreprocessContext(supplied)
+
+    getPreprocessAnalysis('content', context)
+
+    expect(supplied).toEqual({ hideBareFormattingMarkers: false })
+    expect(context).not.toBe(supplied)
+  })
+
+  it('caches paragraphs independently by trailing-empty behavior', () => {
+    const analysis = getPreprocessAnalysis('first\n\nlast\n')
+
+    expect(analysis.getLastParagraph().content).toBe('')
+    expect(analysis.getLastParagraph(true).content).toBe('last\n')
+    expect(analysis.getLastParagraph(true))
+      .toBe(analysis.getLastParagraph(true))
+  })
+})

--- a/test/markmend/preprocess/context.test.ts
+++ b/test/markmend/preprocess/context.test.ts
@@ -1,4 +1,9 @@
-import { createPreprocessContext, getPreprocessAnalysis } from '@markmend/core'
+import {
+  createPreprocessContext,
+  DEFAULT_PREPROCESS_STEPS,
+  getPreprocessAnalysis,
+  preprocess,
+} from '@markmend/core'
 import { describe, expect, it } from 'vitest'
 
 describe('preprocess context', () => {
@@ -42,5 +47,42 @@ describe('preprocess context', () => {
     expect(analysis.getLastParagraph(true).content).toBe('last\n')
     expect(analysis.getLastParagraph(true))
       .toBe(analysis.getLastParagraph(true))
+  })
+
+  it('keeps every step usable without a context', () => {
+    const inputs = {
+      code: 'Text `code',
+      comparisonOperators: '- > 25',
+      delete: 'Text ~~deleted',
+      emphasis: 'Text *italic',
+      footnote: 'Text [^missing]',
+      html: 'Text <span',
+      inlineMath: 'Text $$x + y',
+      link: 'Text [link](',
+      math: '$$\nx + y',
+      strong: 'Text **bold',
+      table: '| a | b |\n| ---',
+      taskList: 'Text\n- [',
+    } as const
+
+    for (const [name, step] of Object.entries(DEFAULT_PREPROCESS_STEPS)) {
+      const input = inputs[name as keyof typeof inputs]
+      expect(step(input)).toBe(step(input, createPreprocessContext()))
+    }
+  })
+
+  it('passes one context through custom steps', () => {
+    let receivedContext: unknown
+    const suppliedContext = { hideBareFormattingMarkers: false }
+
+    preprocess('content', suppliedContext, {
+      code(content, context) {
+        receivedContext = context
+        return content
+      },
+    })
+
+    expect(receivedContext).toEqual(suppliedContext)
+    expect(receivedContext).not.toBe(suppliedContext)
   })
 })

--- a/test/markmend/preprocess/index.test.ts
+++ b/test/markmend/preprocess/index.test.ts
@@ -1,4 +1,4 @@
-import { normalize, preprocess } from '@markmend/core'
+import { normalize, parseMarkdownIntoBlocks, preprocess } from '@markmend/core'
 import { describe, expect, it } from 'vitest'
 import { getTestCases, getTestCasesByCategory } from './test-cases'
 import { getFixtureFiles, getSnapshotPath, readFixture } from './utils'
@@ -7,6 +7,56 @@ describe('normalize', () => {
   it('should convert LaTeX syntax and normalize content', () => {
     expect(normalize('\\[E = mc^2\\]')).toBe('$$E = mc^2$$')
     expect(normalize('\\(x = 1\\)')).toBe('$$x = 1$$')
+  })
+})
+
+describe('parseMarkdownIntoBlocks', () => {
+  it('should keep nested same-name HTML elements in one block', () => {
+    const markdown = '<div>\n<div>\ninner\n</div>\n\nafter inner\n</div>\n\noutside'
+
+    expect(parseMarkdownIntoBlocks(markdown)).toEqual([
+      '<div>\n<div>\ninner\n</div>\n\nafter inner\n</div>\n\n',
+      'outside',
+    ])
+  })
+
+  it('should keep custom HTML elements and trailing whitespace together', () => {
+    const markdown = '<my-box>\ninside\n</my-box>\n\noutside'
+
+    expect(parseMarkdownIntoBlocks(markdown)).toEqual([
+      '<my-box>\ninside\n</my-box>\n\n',
+      'outside',
+    ])
+  })
+
+  it('should merge lexer tokens until an open math span closes', () => {
+    const markdown = 'Before $$\nx\n=\ny\n$$\n\nafter'
+
+    expect(parseMarkdownIntoBlocks(markdown)).toEqual([
+      'Before $$\nx\n=\ny\n$$',
+      '\n\n',
+      'after',
+    ])
+  })
+
+  it('should not merge a code block containing shell variables with the next block', () => {
+    const markdown = '```sh\necho $$\n```\n\nafter'
+
+    expect(parseMarkdownIntoBlocks(markdown)).toEqual([
+      '```sh\necho $$\n```',
+      '\n\n',
+      'after',
+    ])
+  })
+
+  it('should not treat regex character classes as footnotes', () => {
+    const markdown = 'Pattern [^\\s+] example.\n\nNext paragraph.'
+
+    expect(parseMarkdownIntoBlocks(markdown)).toEqual([
+      'Pattern [^\\s+] example.',
+      '\n\n',
+      'Next paragraph.',
+    ])
   })
 })
 


### PR DESCRIPTION
## Summary

- share preprocessing analysis through a reusable context to avoid repeated scans
- reuse stable blocks and ASTs while only reprocessing the changing streaming tail
- omit optional position metadata from the default normalized AST to reduce retained memory
- harden HTML, math, code, and footnote block segmentation while preserving incremental parsing
- add isolated completion, parser pipeline, competitor, and retained-memory benchmarks

## Results

- retained heap for the large parser fixture: about 570 KB -> 267 KB per parser (~53% reduction)
- serialized AST size: about 400 KB -> 115 KB (~71% reduction)
- large stable-prefix streaming session: about 19.3 ms, compared with about 56.7 ms for the equivalent Streamdown/remend pipeline
- incremental block results are verified against fresh full parsing across arbitrary chunk boundaries

## Validation

- `pnpm test -- --run` (32 files, 1,200 tests)
- `pnpm build` (8 packages)
- `pnpm exec tsc --noEmit`
- parser benchmark suite