### PR TITLE
fix(vue): restore image carousel navigation

### DIFF
--- a/packages/vue/src/components/renderers/image-node.vue
+++ b/packages/vue/src/components/renderers/image-node.vue
@@ -8,6 +8,7 @@ const props = defineProps<{
   loading?: boolean
   node: ElementNode
   nodeKey: string
+  sources?: string[]
 }>()
 
 const {
@@ -137,6 +138,7 @@ function setMaskOpacity(opacity: number) {
         :title="title"
         :preview="!fallbackAttempted && enablePreview"
         :referrer-policy="imageOptions?.referrerPolicy"
+        :sources="sources"
         :controls="controls"
         :transform-harden-url="transformHardenUrl"
         :node-props="controlContext"

--- a/packages/vue/src/components/renderers/markdown/index.ts
+++ b/packages/vue/src/components/renderers/markdown/index.ts
@@ -1,9 +1,10 @@
 import type { Node } from '@markmend/parser'
 import type { PropType } from 'vue'
 import type { MarkdownComponents } from '../../../types'
-import { defineComponent } from 'vue'
+import { computed, defineComponent } from 'vue'
 import { useContext } from '../../../composables'
 import { createNodeRenderer } from './node-renderer'
+import { collectImageSources } from './node-utils'
 
 export default defineComponent({
   name: 'MarkdownNodes',
@@ -20,12 +21,14 @@ export default defineComponent({
   },
   setup(props) {
     const context = useContext()
+    const imageSources = computed(() => collectImageSources(props.nodes))
     const animatedTextKeys = new Set<string>()
     let renderedTextKeys = new Set<string>()
     const renderNodes = createNodeRenderer({
       animatedTextKeys,
       context,
       getComponents: () => props.components,
+      getImageSources: () => imageSources.value,
       markTextRendered: key => renderedTextKeys.add(key),
     })
 

--- a/packages/vue/src/components/renderers/markdown/node-renderer.ts
+++ b/packages/vue/src/components/renderers/markdown/node-renderer.ts
@@ -21,6 +21,7 @@ export interface NodeRendererOptions {
   animatedTextKeys: Set<string>
   context: StreamMarkdownResolvedContext
   getComponents: () => MarkdownComponents
+  getImageSources: () => string[]
   markTextRendered: (key: string) => void
 }
 
@@ -99,6 +100,7 @@ export function createNodeRenderer(options: NodeRendererOptions) {
         loading,
         node,
         nodeKey: key,
+        sources: options.getImageSources(),
       })
     }
 

--- a/packages/vue/src/components/renderers/markdown/node-utils.ts
+++ b/packages/vue/src/components/renderers/markdown/node-utils.ts
@@ -25,6 +25,26 @@ export function findLastRenderableIndex(nodes: Node[]): number {
   return -1
 }
 
+export function collectImageSources(nodes: Node[]): string[] {
+  const sources: string[] = []
+
+  function visit(children: Node[]) {
+    for (const child of children) {
+      if (typeof child === 'string')
+        continue
+
+      const [tag, attrs, ...nestedChildren] = child
+      if (tag === 'img' && typeof attrs.src === 'string' && attrs.src)
+        sources.push(attrs.src)
+
+      visit(nestedChildren)
+    }
+  }
+
+  visit(nodes)
+  return sources
+}
+
 export function resolveNodeDirection(
   tag: string,
   node: Node,

--- a/test/vue/image.test.ts
+++ b/test/vue/image.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 import { flushPromises, mount } from '@vue/test-utils'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { defineComponent, h } from 'vue'
 import Image from '../../packages/vue/src/components/image.vue'
 import { useContext } from '../../packages/vue/src/composables'
@@ -13,7 +13,23 @@ const PassthroughModal = defineComponent({
 
 const PassthroughZoomContainer = defineComponent({
   setup(_, { slots }) {
-    return () => h('div', { 'data-test': 'zoom-container' }, slots.default?.())
+    return () => h('div', { 'data-test': 'zoom-container' }, [
+      slots.controls?.({}),
+      slots.default?.(),
+    ])
+  },
+})
+
+const PassthroughButton = defineComponent({
+  props: {
+    name: String,
+  },
+  emits: ['click'],
+  setup(props, { emit }) {
+    return () => h('button', {
+      'aria-label': props.name,
+      'onClick': (event: MouseEvent) => emit('click', event),
+    })
   },
 })
 
@@ -54,6 +70,58 @@ describe('image component', () => {
     expect(images.map(image => image.attributes('referrerpolicy'))).toEqual([
       'no-referrer',
       'no-referrer',
+    ])
+  })
+
+  it('switches between provided image sources', async () => {
+    const WrappedImage = defineComponent({
+      setup() {
+        const { provideContext } = useContext()
+
+        provideContext({
+          uiComponents: {
+            Button: PassthroughButton,
+            Modal: PassthroughModal,
+            ZoomContainer: PassthroughZoomContainer,
+          } as never,
+        })
+
+        return () => h(Image, {
+          src: 'https://example.com/first.png',
+          sources: [
+            'https://example.com/first.png',
+            'https://example.com/second.png',
+          ],
+          alt: 'Example',
+          controls: {
+            image: {
+              carousel: true,
+              download: false,
+              flip: false,
+              rotate: false,
+            },
+          },
+          nodeProps: {},
+        })
+      },
+    })
+
+    const wrapper = mount(WrappedImage)
+    await wrapper.get('img').trigger('load')
+    await wrapper.get('img').trigger('click')
+    await vi.dynamicImportSettled()
+    await flushPromises()
+
+    expect(wrapper.findAll('img').map(image => image.attributes('src'))).toEqual([
+      'https://example.com/first.png',
+      'https://example.com/first.png',
+    ])
+
+    await wrapper.get('button[aria-label="Next"]').trigger('click')
+
+    expect(wrapper.findAll('img').map(image => image.attributes('src'))).toEqual([
+      'https://example.com/first.png',
+      'https://example.com/second.png',
     ])
   })
 })

--- a/test/vue/markdown.test.ts
+++ b/test/vue/markdown.test.ts
@@ -62,6 +62,41 @@ describe('stream markdown', () => {
     wrapper.unmount()
   })
 
+  it('provides every document image to the image renderer', async () => {
+    let sources: string[] | undefined
+    const Image = markRaw(defineComponent({
+      inheritAttrs: false,
+      props: {
+        sources: Array<string>,
+        src: String,
+      },
+      setup(props) {
+        sources = props.sources
+        return () => h('img', { src: props.src })
+      },
+    }))
+    const wrapper = mount(Markdown, {
+      props: {
+        content: [
+          '![First](https://example.com/first.png)',
+          '![Second](https://example.com/second.png)',
+        ].join('\n\n'),
+        mode: 'static',
+        uiComponents: { Image },
+      },
+    })
+
+    await flushPromises()
+    await vi.dynamicImportSettled()
+    await flushPromises()
+
+    expect(sources).toEqual([
+      'https://example.com/first.png',
+      'https://example.com/second.png',
+    ])
+    wrapper.unmount()
+  })
+
   it('preserves stable block elements while the tail grows', async () => {
     const wrapper = mount(Markdown, {
       props: {


### PR DESCRIPTION
## Summary

- collect image sources once per rendered document
- pass the shared source list to each image renderer
- restore previous and next navigation in image previews

## Validation

- `pnpm lint --fix`
- `pnpm typecheck`
- `pnpm test --run`
- verified navigation in the Nuxt playground