### PR TITLE
fix(vue): prevent ordered list marker clipping

### DIFF
--- a/packages/vue/__snapshots__/tsnapi/index.snapshot.js
+++ b/packages/vue/__snapshots__/tsnapi/index.snapshot.js
@@ -41,13 +41,13 @@ export*from"@markmend/parser";
 // #endregion
 
 // #region Other
-export { F as ANIMATION_SPLITS }
-export { de as ANIMATION_TYPES }
-export { fe as CARETS }
-export { I as DEFAULT_ANIMATION }
-export { R as DEFAULT_ANIMATION_SPLIT }
-export { V as DEFAULT_HARDEN_OPTIONS }
-export { H as DEFAULT_LANGUAGE }
-export { W as SHADCN_SCHEMAS }
-export { G as SUPPORT_LANGUAGES }
+export { M as ANIMATION_SPLITS }
+export { N as ANIMATION_TYPES }
+export { P as CARETS }
+export { F as DEFAULT_ANIMATION }
+export { L as DEFAULT_ANIMATION_SPLIT }
+export { B as DEFAULT_HARDEN_OPTIONS }
+export { V as DEFAULT_LANGUAGE }
+export { U as SHADCN_SCHEMAS }
+export { W as SUPPORT_LANGUAGES }
 // #endregion

--- a/packages/vue/src/components/renderers/markdown/node-renderer.ts
+++ b/packages/vue/src/components/renderers/markdown/node-renderer.ts
@@ -3,7 +3,7 @@ import type { TextAnimationScheduler } from '@stream-markdown/core'
 import type { VNodeChild } from 'vue'
 import type { MarkdownComponents, StreamMarkdownResolvedContext } from '../../../types'
 import { createCommentVNode, defineAsyncComponent, h } from 'vue'
-import { BLOCK_STYLES, ELEMENT_STYLES } from './node-styles'
+import { BLOCK_STYLES, ELEMENT_STYLES, ORDERED_LIST_STYLES } from './node-styles'
 import {
   findLastRenderableIndex,
   resolveAttributes,
@@ -63,17 +63,17 @@ export function createNodeRenderer(options: NodeRendererOptions) {
     return h(tag, {
       ...attrs,
       key,
-      'class': [...className, 'stream-markdown-ordered-item'],
+      'class': [...className, ORDERED_LIST_STYLES.item],
       'style': [attrs.style, { paddingInlineStart: 0 }],
       'data-stream-markdown': resolveDataAttribute(tag),
     }, [
       h('span', {
         'aria-hidden': 'true',
-        'class': 'stream-markdown-list-marker',
+        'class': ORDERED_LIST_STYLES.marker,
         'data-stream-markdown': 'list-marker',
       }, `${orderedListItemNumber}.`),
       h('div', {
-        'class': 'stream-markdown-list-item-content',
+        'class': ORDERED_LIST_STYLES.content,
         'data-stream-markdown': 'list-item-content',
       }, renderNodes(children, loading, key, hideCaret)),
     ])

--- a/packages/vue/src/components/renderers/markdown/node-renderer.ts
+++ b/packages/vue/src/components/renderers/markdown/node-renderer.ts
@@ -31,22 +31,84 @@ const TableNode = defineAsyncComponent(() => import('../table-node.vue'))
 export function createNodeRenderer(options: NodeRendererOptions) {
   const { context } = options
 
+  function renderListNode(
+    tag: string,
+    attrs: Record<string, unknown>,
+    className: unknown[],
+    children: Node[],
+    loading: boolean,
+    key: string,
+    hideCaret: boolean,
+    orderedListItemNumber: number | undefined,
+  ): VNodeChild {
+    if (tag === 'ol') {
+      const hasCustomListItem = Boolean(options.getComponents().li)
+      const orderedListClassName = hasCustomListItem
+        ? ['leading-6 pl-5 whitespace-normal list-decimal', attrs.class]
+        : className
+      return h(tag, {
+        ...attrs,
+        key,
+        'class': orderedListClassName,
+        'data-stream-markdown': resolveDataAttribute(tag),
+      }, renderNodes(
+        children,
+        loading,
+        key,
+        hideCaret,
+        hasCustomListItem ? undefined : resolveOrderedListStart(attrs),
+      ))
+    }
+
+    return h(tag, {
+      ...attrs,
+      key,
+      'class': [...className, 'stream-markdown-ordered-item'],
+      'style': [attrs.style, { paddingInlineStart: 0 }],
+      'data-stream-markdown': resolveDataAttribute(tag),
+    }, [
+      h('span', {
+        'aria-hidden': 'true',
+        'class': 'stream-markdown-list-marker',
+        'data-stream-markdown': 'list-marker',
+      }, `${orderedListItemNumber}.`),
+      h('div', {
+        'class': 'stream-markdown-list-item-content',
+        'data-stream-markdown': 'list-item-content',
+      }, renderNodes(children, loading, key, hideCaret)),
+    ])
+  }
+
   function renderNodes(
     nodes: Node[],
     loading: boolean,
     parentKey = 'root',
     hideCaret = false,
+    orderedListStart?: number,
   ): VNodeChild[] {
     const lastIndex = findLastRenderableIndex(nodes)
-    return nodes.map((node, index) => renderNode(
-      node,
-      loading && index === lastIndex,
-      `${parentKey}-${index}`,
-      hideCaret,
-    ))
+    let nextOrderedListItemNumber = orderedListStart ?? 1
+    return nodes.map((node, index) => {
+      const orderedListItemNumber = orderedListStart !== undefined && isOrderedListItem(node)
+        ? nextOrderedListItemNumber++
+        : undefined
+      return renderNode(
+        node,
+        loading && index === lastIndex,
+        `${parentKey}-${index}`,
+        hideCaret,
+        orderedListItemNumber,
+      )
+    })
   }
 
-  function renderNode(node: Node, loading: boolean, path: string, hideCaret: boolean): VNodeChild {
+  function renderNode(
+    node: Node,
+    loading: boolean,
+    path: string,
+    hideCaret: boolean,
+    orderedListItemNumber?: number,
+  ): VNodeChild {
     if (typeof node === 'string')
       return renderTextNode(node, loading && !hideCaret, path, options)
 
@@ -90,6 +152,9 @@ export function createNodeRenderer(options: NodeRendererOptions) {
       ELEMENT_STYLES[tag],
       resolvedAttrs.class,
     ]
+
+    if (tag === 'ol' || orderedListItemNumber !== undefined)
+      return renderListNode(tag, resolvedAttrs, className, children, loading, key, hideCaret, orderedListItemNumber)
 
     if (tag === 'a') {
       const completion = options.getCompletionInfo()
@@ -150,4 +215,19 @@ export function createNodeRenderer(options: NodeRendererOptions) {
   }
 
   return renderNodes
+}
+
+function resolveOrderedListStart(attrs: Record<string, unknown>): number {
+  const start = attrs.start
+  if (typeof start === 'number' && Number.isInteger(start))
+    return start
+
+  if (typeof start === 'string' && /^-?\d+$/.test(start))
+    return Number(start)
+
+  return 1
+}
+
+function isOrderedListItem(node: Node): boolean {
+  return typeof node !== 'string' && node[0] === 'li'
 }

--- a/packages/vue/src/components/renderers/markdown/node-styles.ts
+++ b/packages/vue/src/components/renderers/markdown/node-styles.ts
@@ -6,7 +6,7 @@ export const BLOCK_STYLES: Record<string, string> = {
   h4: 'font-semibold mb-2 mt-6 text-lg',
   h5: 'font-semibold mb-2 mt-6 text-base',
   h6: 'font-semibold mb-2 mt-6 text-sm',
-  ol: 'leading-6 pl-5 whitespace-normal list-decimal',
+  ol: 'leading-6 whitespace-normal list-none stream-markdown-ordered-list',
   p: 'my-4 align-middle transition-[height] duration-[var(--default-transition-duration)] ease',
   ul: 'leading-6 pl-5 whitespace-normal list-disc',
 }

--- a/packages/vue/src/components/renderers/markdown/node-styles.ts
+++ b/packages/vue/src/components/renderers/markdown/node-styles.ts
@@ -6,10 +6,16 @@ export const BLOCK_STYLES: Record<string, string> = {
   h4: 'font-semibold mb-2 mt-6 text-lg',
   h5: 'font-semibold mb-2 mt-6 text-base',
   h6: 'font-semibold mb-2 mt-6 text-sm',
-  ol: 'leading-6 whitespace-normal list-none stream-markdown-ordered-list',
+  ol: 'leading-6 whitespace-normal list-none',
   p: 'my-4 align-middle transition-[height] duration-[var(--default-transition-duration)] ease',
   ul: 'leading-6 pl-5 whitespace-normal list-disc',
 }
+
+export const ORDERED_LIST_STYLES = {
+  item: 'grid grid-cols-[minmax(1.25rem,max-content)_minmax(0,1fr)] gap-x-1',
+  marker: 'text-end select-none',
+  content: 'min-w-0',
+} as const
 
 export const ELEMENT_STYLES: Record<string, string> = {
   a: 'text-primary underline cursor-pointer [overflow-wrap:anywhere]',

--- a/packages/vue/src/style.css
+++ b/packages/vue/src/style.css
@@ -28,26 +28,6 @@
     margin-bottom: 0 !important;
   }
 
-  & .stream-markdown-ordered-list {
-    list-style: none;
-    padding-inline-start: 0;
-  }
-
-  & .stream-markdown-ordered-item {
-    display: grid;
-    grid-template-columns: minmax(1.25rem, max-content) minmax(0, 1fr);
-    column-gap: 0.25rem;
-  }
-
-  & .stream-markdown-list-marker {
-    text-align: end;
-    user-select: none;
-  }
-
-  & .stream-markdown-list-item-content {
-    min-width: 0;
-  }
-
   & ::-webkit-scrollbar {
     width: 6px;
     height: 6px;

--- a/packages/vue/src/style.css
+++ b/packages/vue/src/style.css
@@ -28,6 +28,26 @@
     margin-bottom: 0 !important;
   }
 
+  & .stream-markdown-ordered-list {
+    list-style: none;
+    padding-inline-start: 0;
+  }
+
+  & .stream-markdown-ordered-item {
+    display: grid;
+    grid-template-columns: minmax(1.25rem, max-content) minmax(0, 1fr);
+    column-gap: 0.25rem;
+  }
+
+  & .stream-markdown-list-marker {
+    text-align: end;
+    user-select: none;
+  }
+
+  & .stream-markdown-list-item-content {
+    min-width: 0;
+  }
+
   & ::-webkit-scrollbar {
     width: 6px;
     height: 6px;

--- a/test/vue/markdown-renderer.test.ts
+++ b/test/vue/markdown-renderer.test.ts
@@ -73,6 +73,19 @@ describe('markdown renderer', () => {
     wrapper.unmount()
   })
 
+  it('renders ordered list markers without clipping multi-digit values', async () => {
+    const nodes = shallowRef<Node[]>([
+      ['ol', { start: '98' }, ['li', {}, 'Ninety-eight'], ['li', {}, 'Ninety-nine'], ['li', {}, 'One hundred']],
+    ])
+    const wrapper = mountNodes(nodes)
+
+    const markers = wrapper.findAll('[data-stream-markdown="list-marker"]')
+    expect(markers.map(marker => marker.text())).toEqual(['98.', '99.', '100.'])
+    expect(wrapper.get('ol').classes()).toContain('stream-markdown-ordered-list')
+    expect(wrapper.findAll('[data-stream-markdown="list-item-content"]')).toHaveLength(3)
+    wrapper.unmount()
+  })
+
   it('passes attributes, children, and the raw node to custom components', () => {
     let receivedNode: Node | undefined
     const Callout = defineComponent({

--- a/test/vue/markdown-renderer.test.ts
+++ b/test/vue/markdown-renderer.test.ts
@@ -81,7 +81,9 @@ describe('markdown renderer', () => {
 
     const markers = wrapper.findAll('[data-stream-markdown="list-marker"]')
     expect(markers.map(marker => marker.text())).toEqual(['98.', '99.', '100.'])
-    expect(wrapper.get('ol').classes()).toContain('stream-markdown-ordered-list')
+    expect(wrapper.get('ol').classes()).toContain('list-none')
+    expect(wrapper.get('li').classes()).toContain('grid')
+    expect(wrapper.get('li').classes()).toContain('gap-x-1')
     expect(wrapper.findAll('[data-stream-markdown="list-item-content"]')).toHaveLength(3)
     wrapper.unmount()
   })


### PR DESCRIPTION
### What
Render ordered-list markers in an auto-sized marker column and cover multi-digit and custom-start lists.

### Why
The fixed native marker gutter clipped the leading digit of 10/11 and larger list numbers. This keeps marker and content alignment stable for any marker width.

Closes #74