### PR TITLE
perf(vue): preserve stable markdown blocks during streaming

### DIFF
--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -6,7 +6,8 @@
     "bench:code": "vitest bench --run code.bench.ts",
     "bench:completion": "vitest bench --run completion.bench.ts",
     "bench:parser": "vitest bench --run parser.bench.ts",
-    "bench:render": "vitest bench --run render.bench.ts"
+    "bench:render": "vitest bench --run render.bench.ts",
+    "bench:stable-tail": "vitest bench --run stable-tail.bench.ts --reporter=verbose"
   },
   "devDependencies": {
     "@streamdown/code": "catalog:benchmark",

--- a/benchmark/stable-tail.bench.ts
+++ b/benchmark/stable-tail.bench.ts
@@ -1,0 +1,140 @@
+// @vitest-environment happy-dom
+
+import type { BenchRunOptions } from 'vitest'
+import type { MarkdownComponents } from 'vue-stream-markdown'
+import { afterAll, beforeAll, describe, it } from 'vitest'
+import { defineComponent, h, markRaw, nextTick, render } from 'vue'
+import { Markdown } from 'vue-stream-markdown'
+
+const WORDS = [
+  'and',
+  'the',
+  'trailing',
+  'narrative',
+  'continues',
+  'to',
+  'arrive',
+  'one',
+  'token',
+  'at',
+  'a',
+  'time',
+]
+
+const INITIAL_CONTENT = '::callout\nStable callout\n::\n\nTail'
+const APPEND_COUNT = 20
+const CHILD_COUNT = 1024
+
+interface CustomRendererStats {
+  renderCount: number
+  renderTime: number
+}
+
+interface SessionResult extends CustomRendererStats {
+  textLength: number
+}
+
+const benchmarkOptions: BenchRunOptions = {
+  time: 1000,
+  warmupTime: 500,
+}
+let benchmarkResult: SessionResult | undefined
+
+function createCallout(stats: CustomRendererStats) {
+  return markRaw(defineComponent({
+    name: 'BenchmarkCallout',
+    setup(_props, { slots }) {
+      return () => {
+        const startedAt = performance.now()
+        stats.renderCount += 1
+        const children = Array.from({ length: CHILD_COUNT }, (_, index) => (
+          h('span', { key: index }, `child-${index}`)
+        ))
+        const rendered = h('aside', { 'data-benchmark-callout': '' }, [
+          slots.default?.(),
+          ...children,
+        ])
+        stats.renderTime += performance.now() - startedAt
+        return rendered
+      }
+    },
+  }))
+}
+
+function createHost(): HTMLDivElement {
+  const host = document.createElement('div')
+  document.body.appendChild(host)
+  return host
+}
+
+function renderSession(
+  host: HTMLElement,
+  content: string,
+  components: MarkdownComponents,
+): void {
+  render(h(Markdown, {
+    components,
+    content,
+    controls: false,
+    enableAnimate: false,
+    mode: 'streaming',
+    previewers: false,
+  }), host)
+}
+
+async function waitForText(host: HTMLElement, text: string): Promise<void> {
+  const deadline = performance.now() + 10_000
+  while (performance.now() < deadline) {
+    await Promise.resolve()
+    await nextTick()
+    await new Promise(resolve => setTimeout(resolve, 0))
+    if (host.textContent?.includes(text))
+      return
+  }
+
+  throw new Error(`Timed out waiting for Vue output: ${text}`)
+}
+
+async function runSession(): Promise<SessionResult> {
+  const host = createHost()
+  const stats: CustomRendererStats = { renderCount: 0, renderTime: 0 }
+  const components = { callout: createCallout(stats) }
+  let content = INITIAL_CONTENT
+
+  renderSession(host, content, components)
+  await waitForText(host, 'Stable callout')
+
+  for (let step = 0; step < APPEND_COUNT; step += 1) {
+    const word = WORDS[step % WORDS.length] ?? ''
+    content += ` ${word}`
+    renderSession(host, content, components)
+    await waitForText(host, word)
+  }
+
+  const result = {
+    renderCount: stats.renderCount,
+    renderTime: stats.renderTime,
+    textLength: host.textContent?.length ?? 0,
+  }
+  render(null, host)
+  host.remove()
+  return result
+}
+
+beforeAll(async () => {
+  benchmarkResult = await runSession()
+  console.error('stable tail custom renderer diagnostics', benchmarkResult)
+}, 30_000)
+
+afterAll(() => {
+  if (benchmarkResult === undefined)
+    throw new Error('Stable tail benchmark did not produce a result')
+})
+
+describe('stable tail custom renderer', () => {
+  it('renders a stable custom component across 20 streaming appends', async ({ bench }) => {
+    await bench('vue-stream-markdown', async () => {
+      benchmarkResult = await runSession()
+    }).run(benchmarkOptions)
+  })
+})

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "bench:completion": "pnpm -F benchmark bench:completion",
     "bench:parser": "pnpm -F benchmark bench:parser",
     "bench:render": "pnpm -F benchmark bench:render",
+    "bench:stable-tail": "pnpm -F benchmark bench:stable-tail",
     "playground:dev": "pnpm -F nuxt-playground dev",
     "playground:build": "pnpm -F nuxt-playground generate",
     "playground:typecheck": "pnpm -F nuxt-playground typecheck",

--- a/packages/core/src/utils/animation.ts
+++ b/packages/core/src/utils/animation.ts
@@ -69,8 +69,12 @@ export function createAnimationTimeline(
       const minimumStep = idealStep === 0
         ? 0
         : Math.min(idealStep, minStagger)
-      const start = Math.max(pendingNextStart, currentTime)
       const budgetEnd = currentTime + maxBacklog
+      const queuedStart = Math.max(pendingNextStart, currentTime)
+      // Do not let a long document push later nodes indefinitely into the
+      // future. Once the queue has fallen behind the display budget, start a
+      // fresh local sequence for the remaining nodes in this pass.
+      const start = queuedStart >= budgetEnd ? currentTime : queuedStart
       const idealEnd = start + Math.max(0, count - 1) * idealStep
       let step = idealStep
 

--- a/packages/vue/__snapshots__/tsnapi/index.snapshot.js
+++ b/packages/vue/__snapshots__/tsnapi/index.snapshot.js
@@ -41,13 +41,13 @@ export*from"@markmend/parser";
 // #endregion
 
 // #region Other
-export { M as ANIMATION_SPLITS }
-export { N as ANIMATION_TYPES }
-export { P as CARETS }
-export { F as DEFAULT_ANIMATION }
-export { L as DEFAULT_ANIMATION_SPLIT }
-export { B as DEFAULT_HARDEN_OPTIONS }
-export { V as DEFAULT_LANGUAGE }
-export { U as SHADCN_SCHEMAS }
-export { W as SUPPORT_LANGUAGES }
+export { j as ANIMATION_SPLITS }
+export { M as ANIMATION_TYPES }
+export { N as CARETS }
+export { P as DEFAULT_ANIMATION }
+export { I as DEFAULT_ANIMATION_SPLIT }
+export { z as DEFAULT_HARDEN_OPTIONS }
+export { B as DEFAULT_LANGUAGE }
+export { H as SHADCN_SCHEMAS }
+export { U as SUPPORT_LANGUAGES }
 // #endregion

--- a/packages/vue/src/components/renderers/markdown/index.ts
+++ b/packages/vue/src/components/renderers/markdown/index.ts
@@ -86,8 +86,8 @@ export default defineComponent({
     const reconcileRenderedTextKeys = () => {
       const renderedTextKeys = new Set<string>()
       const activePaths = new Set<string>()
-      props.nodes.forEach((_, index) => {
-        const path = `root-${index}`
+      props.nodes.forEach((node, index) => {
+        const path = resolveTopLevelPath(node, index)
         activePaths.add(path)
         for (const key of renderedTextKeysByPath.get(path) ?? [])
           renderedTextKeys.add(key)
@@ -118,16 +118,26 @@ export default defineComponent({
       })
       const lastIndex = findLastRenderableIndex(props.nodes)
       return props.nodes.map((node, index) => {
+        const path = resolveTopLevelPath(node, index)
         const tag = typeof node === 'string' ? 'text' : node[0] ?? 'comment'
         return h(MarkdownBlock, {
-          key: `root-${index}-${tag}`,
+          key: `${path}-${tag}`,
           components: props.components,
           loading: props.loading && index === lastIndex,
           node,
           onRendered: onBlockRendered,
-          path: `root-${index}`,
+          path,
         })
       })
     }
   },
 })
+
+function resolveTopLevelPath(node: Node, index: number): string {
+  if (Array.isArray(node)) {
+    const [tag, attrs] = node
+    if (tag === 'section' && attrs && attrs.class === 'footnotes')
+      return 'root-footnotes'
+  }
+  return `root-${index}`
+}

--- a/packages/vue/src/components/renderers/markdown/index.ts
+++ b/packages/vue/src/components/renderers/markdown/index.ts
@@ -2,10 +2,10 @@ import type { CompletionInfo, Node } from '@markmend/parser'
 import type { PropType } from 'vue'
 import type { MarkdownComponents } from '../../../types'
 import { createTextAnimationScheduler } from '@stream-markdown/core'
-import { computed, defineComponent, onMounted, onUpdated } from 'vue'
+import { computed, defineComponent, h, onMounted, onUpdated } from 'vue'
 import { useContext } from '../../../composables'
 import { createNodeRenderer } from './node-renderer'
-import { collectImageSources } from './node-utils'
+import { collectImageSources, findLastRenderableIndex } from './node-utils'
 
 export default defineComponent({
   name: 'MarkdownNodes',
@@ -28,33 +28,106 @@ export default defineComponent({
     const context = useContext()
     const imageSources = computed(() => collectImageSources(props.nodes))
     const animatedTextKeys = new Set<string>()
-    let renderedTextKeys = new Set<string>()
     const textAnimationScheduler = createTextAnimationScheduler()
-    const renderNodes = createNodeRenderer({
-      animatedTextKeys,
-      context,
-      getCompletionInfo: () => props.completionInfo,
-      getComponents: () => props.components,
-      getImageSources: () => imageSources.value,
-      markTextRendered: key => renderedTextKeys.add(key),
-      textAnimationScheduler,
+    const renderedTextKeysByPath = new Map<string, Set<string>>()
+
+    const onBlockRendered = (path: string, keys: Set<string>) => {
+      renderedTextKeysByPath.set(path, keys)
+    }
+
+    const MarkdownBlock = defineComponent({
+      name: 'MarkdownBlock',
+      props: {
+        components: {
+          type: Object as PropType<MarkdownComponents>,
+          required: true,
+        },
+        hideCaret: Boolean,
+        loading: Boolean,
+        node: {
+          type: [String, Array] as PropType<Node>,
+          required: true,
+        },
+        onRendered: {
+          type: Function as PropType<typeof onBlockRendered>,
+          required: true,
+        },
+        path: {
+          type: String,
+          required: true,
+        },
+      },
+      setup(blockProps) {
+        let renderedTextKeys = new Set<string>()
+        const renderer = createNodeRenderer({
+          animatedTextKeys,
+          context,
+          getCompletionInfo: () => props.completionInfo,
+          getComponents: () => blockProps.components,
+          getImageSources: () => imageSources.value,
+          markTextRendered: key => renderedTextKeys.add(key),
+          textAnimationScheduler,
+        })
+
+        return () => {
+          renderedTextKeys = new Set<string>()
+          const rendered = renderer.renderNode(
+            blockProps.node,
+            blockProps.loading,
+            blockProps.path,
+            blockProps.hideCaret,
+          )
+          blockProps.onRendered(blockProps.path, renderedTextKeys)
+          return rendered
+        }
+      },
     })
 
-    onMounted(() => textAnimationScheduler.commitPass())
-    onUpdated(() => textAnimationScheduler.commitPass())
-
-    return () => {
-      renderedTextKeys = new Set<string>()
-      textAnimationScheduler.beginPass({
-        enabled: context.enableAnimate.value,
-        stagger: context.animationStagger.value,
+    const reconcileRenderedTextKeys = () => {
+      const renderedTextKeys = new Set<string>()
+      const activePaths = new Set<string>()
+      props.nodes.forEach((_, index) => {
+        const path = `root-${index}`
+        activePaths.add(path)
+        for (const key of renderedTextKeysByPath.get(path) ?? [])
+          renderedTextKeys.add(key)
       })
-      const rendered = renderNodes(props.nodes, props.loading)
+      for (const path of renderedTextKeysByPath.keys()) {
+        if (!activePaths.has(path))
+          renderedTextKeysByPath.delete(path)
+      }
       for (const key of animatedTextKeys) {
         if (!renderedTextKeys.has(key))
           animatedTextKeys.delete(key)
       }
-      return rendered
+    }
+
+    onMounted(() => {
+      reconcileRenderedTextKeys()
+      textAnimationScheduler.commitPass()
+    })
+    onUpdated(() => {
+      reconcileRenderedTextKeys()
+      textAnimationScheduler.commitPass()
+    })
+
+    return () => {
+      textAnimationScheduler.beginPass({
+        enabled: context.enableAnimate.value,
+        stagger: context.animationStagger.value,
+      })
+      const lastIndex = findLastRenderableIndex(props.nodes)
+      return props.nodes.map((node, index) => {
+        const tag = typeof node === 'string' ? 'text' : node[0] ?? 'comment'
+        return h(MarkdownBlock, {
+          key: `root-${index}-${tag}`,
+          components: props.components,
+          loading: props.loading && index === lastIndex,
+          node,
+          onRendered: onBlockRendered,
+          path: `root-${index}`,
+        })
+      })
     }
   },
 })

--- a/packages/vue/src/components/renderers/markdown/node-renderer.ts
+++ b/packages/vue/src/components/renderers/markdown/node-renderer.ts
@@ -22,13 +22,30 @@ export interface NodeRendererOptions {
   textAnimationScheduler: TextAnimationScheduler
 }
 
+export interface NodeRenderer {
+  renderNode: (
+    node: Node,
+    loading: boolean,
+    path: string,
+    hideCaret: boolean,
+    orderedListItemNumber?: number,
+  ) => VNodeChild
+  renderNodes: (
+    nodes: Node[],
+    loading: boolean,
+    parentKey?: string,
+    hideCaret?: boolean,
+    orderedListStart?: number,
+  ) => VNodeChild[]
+}
+
 const CodeBlock = defineAsyncComponent(() => import('../code-block.vue'))
 const ImageNode = defineAsyncComponent(() => import('../image-node.vue'))
 const LinkNode = defineAsyncComponent(() => import('../link-node.vue'))
 const MathNode = defineAsyncComponent(() => import('../math-node.vue'))
 const TableNode = defineAsyncComponent(() => import('../table-node.vue'))
 
-export function createNodeRenderer(options: NodeRendererOptions) {
+export function createNodeRenderer(options: NodeRendererOptions): NodeRenderer {
   const { context } = options
 
   function renderListNode(
@@ -214,7 +231,7 @@ export function createNodeRenderer(options: NodeRendererOptions) {
     }, renderNodes(children, loading, key, hideCaret))
   }
 
-  return renderNodes
+  return { renderNode, renderNodes }
 }
 
 function resolveOrderedListStart(attrs: Record<string, unknown>): number {

--- a/test/core/animation.test.ts
+++ b/test/core/animation.test.ts
@@ -28,6 +28,15 @@ describe('animation timeline', () => {
     expect(finalDelay).toBeCloseTo(320)
   })
 
+  it('drops an over-budget queue before scheduling later sibling batches', () => {
+    const timeline = createAnimationTimeline({ now: () => 1000 })
+    const now = timeline.beginPass()
+
+    timeline.take(20, 40, now)
+
+    expect(timeline.take(1, 40, now).baseDelay).toBe(0)
+  })
+
   it('drops stale backlog and can be reset', () => {
     let now = 1000
     const timeline = createAnimationTimeline({ now: () => now })

--- a/test/vue/markdown.test.ts
+++ b/test/vue/markdown.test.ts
@@ -151,6 +151,34 @@ describe('stream markdown', () => {
     wrapper.unmount()
   })
 
+  it('does not rerender a stable top-level block while the tail grows', async () => {
+    let renderCount = 0
+    const Callout = markRaw(defineComponent({
+      setup(_props, { slots }) {
+        return () => {
+          renderCount += 1
+          return h('aside', slots.default?.())
+        }
+      },
+    }))
+    const wrapper = mount(Markdown, {
+      props: {
+        components: { callout: Callout },
+        content: '::callout\nStable\n::\n\nTail',
+        mode: 'streaming',
+      },
+    })
+    const testWrapper = wrapper as unknown as MarkdownTestWrapper
+    await flushPromises()
+    expect(renderCount).toBe(1)
+
+    await testWrapper.setProps({ content: '::callout\nStable\n::\n\nTail grows' })
+    await flushPromises()
+
+    expect(renderCount).toBe(1)
+    wrapper.unmount()
+  })
+
   it.each([
     '| Name | Age |\n| --- | --- |',
     '| Name | Age |\n| --- | --- |\n| Alice | 30 |',

--- a/test/vue/markdown.test.ts
+++ b/test/vue/markdown.test.ts
@@ -179,6 +179,61 @@ describe('stream markdown', () => {
     wrapper.unmount()
   })
 
+  it('keeps generated footnotes stable when later blocks arrive', async () => {
+    const wrapper = mount(Markdown, {
+      props: {
+        content: 'Reference[^note]\n\n[^note]: Definition',
+        enableAnimate: false,
+        mode: 'streaming',
+      },
+    })
+    const testWrapper = wrapper as unknown as MarkdownTestWrapper
+    await flushPromises()
+    const footnotes = wrapper.get('section').element
+
+    await testWrapper.setProps({
+      content: 'Reference[^note]\n\n[^note]: Definition\n\n## Later',
+    })
+    await flushPromises()
+
+    expect(wrapper.get('section').element).toBe(footnotes)
+    wrapper.unmount()
+  })
+
+  it('renders animated footnote definitions', async () => {
+    const wrapper = mount(Markdown, {
+      props: {
+        content: 'Reference[^note]\n\n[^note]: Definition',
+        mode: 'streaming',
+      },
+    })
+    await vi.dynamicImportSettled()
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Definition')
+    expect(wrapper.find('[data-stream-markdown="footnote-definition-button"]').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('flushes footnote definitions when streaming switches to static mode', async () => {
+    const content = 'Reference[^note]\n\n[^note]: Definition\n\n## Later\n\nMore'
+    const wrapper = mount(Markdown, {
+      props: {
+        content,
+        enableAnimate: false,
+        mode: 'streaming',
+      },
+    })
+    const testWrapper = wrapper as unknown as MarkdownTestWrapper
+    await flushPromises()
+
+    await testWrapper.setProps({ mode: 'static' })
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Definition')
+    wrapper.unmount()
+  })
+
   it.each([
     '| Name | Age |\n| --- | --- |',
     '| Name | Age |\n| --- | --- |\n| Alice | 30 |',


### PR DESCRIPTION
### What

Preserve stable top-level Markdown blocks while streaming so Vue can reuse their component instances and skip rerendering unchanged custom renderer subtrees. Keep generated footnotes keyed across updates, cap queued animation backlog, and add a focused benchmark that measures the stable custom-renderer path.

### Why

Streaming updates should only do work for the changing tail. Re-rendering stable custom components on every append wastes VNode construction and renderer work, especially for expensive components such as diagrams or cards. The benchmark makes this behavior measurable: the stable custom renderer runs once instead of once per append.