### PR TITLE
feat(vue): add configurable code block variants

### DIFF
--- a/docs/app/components/landing-page.vue
+++ b/docs/app/components/landing-page.vue
@@ -10,7 +10,7 @@ import liveDemo from '../content/landing-page.md?raw'
 
 const { copy, copied } = useClipboard({ legacy: true })
 
-const installCommand = 'npm install vue-stream-markdown'
+const installCommand = 'pnpm add vue-stream-markdown'
 const typingDelay = 20
 const extensions = {
   beautifulMermaid: beautifulMermaid(),
@@ -497,7 +497,7 @@ async function replayStream() {
 }
 
 .landing-markdown {
-  --background: transparent;
+  --background: var(--ui-bg);
   --foreground: var(--landing-ink);
   min-width: 0;
 }

--- a/docs/content/3.config/display-options.md
+++ b/docs/content/3.config/display-options.md
@@ -18,6 +18,7 @@ Configuration for code block display options, including language indicators and 
 
 ```typescript
 interface CodeOptions {
+  variant?: 'modern' | 'classic' | 'minimal'
   languageIcon?: boolean
   languageName?: boolean
   lineNumbers?: boolean
@@ -39,6 +40,19 @@ interface CodeOptionsLanguage extends Omit<CodeOptions, 'languageIcon'> {
 ```
 
 All options default to `true` (visible). Set any option to `false` to hide the corresponding element.
+
+### variant
+
+- **Type:** `'modern' | 'classic' | 'minimal' | undefined`
+- **Default:** `'modern'`
+
+Code block presentation. `modern` uses the nested card style, `classic` keeps the traditional header layout, and `minimal` reduces the header to the action icons (including a single preview/source toggle when preview is available).
+
+```ts
+const codeOptions: CodeOptions = {
+  variant: 'modern',
+}
+```
 
 ### languageIcon
 

--- a/packages/core/__snapshots__/tsnapi/index.snapshot.d.ts
+++ b/packages/core/__snapshots__/tsnapi/index.snapshot.d.ts
@@ -116,6 +116,7 @@ export interface CodeMaxHeightOptions<TComponent = unknown> {
   language: string;
 }
 export interface CodeOptions<TComponent = unknown> {
+  variant?: CodeBlockVariant;
   languageIcon?: boolean;
   languageName?: boolean;
   lineNumbers?: boolean;
@@ -127,6 +128,7 @@ export interface CodeOptionsLanguage<TComponent = unknown> extends Omit<CodeOpti
 }
 export interface CodeOptionsModel<TComponent = unknown> {
   languageCodeOptions: CodeOptionsLanguage<TComponent>;
+  variant: CodeBlockVariant;
   showLanguageIcon: boolean;
   showLanguageName: boolean;
   showLineNumbers: boolean;
@@ -642,6 +644,7 @@ export type BuiltinPreviewers = 'mermaid' | 'html';
 export type BuiltinUIComponents = 'Alert' | 'Button' | 'Caret' | 'CodeBlock' | 'Dropdown' | 'ErrorComponent' | 'Icon' | 'Image' | 'Modal' | 'Segmented' | 'Spin' | 'Table' | 'Tooltip' | 'ZoomContainer';
 export type CaretType = 'block' | 'circle';
 export type CdnModule = 'shiki' | 'mermaid' | 'beautiful-mermaid' | 'katex' | 'katex-css';
+export type CodeBlockVariant = 'modern' | 'classic' | 'minimal';
 export type CodeControlsConfig<TTransformer = unknown> = boolean | {
   collapse?: boolean;
   copy?: boolean;

--- a/packages/core/src/core/code.ts
+++ b/packages/core/src/core/code.ts
@@ -1,4 +1,5 @@
 import type {
+  CodeBlockVariant,
   CodeOptions,
   CodeOptionsLanguage,
   ControlDescriptor,
@@ -80,6 +81,7 @@ export interface CodeBlockModeState {
 
 export interface CodeOptionsModel<TComponent = unknown> {
   languageCodeOptions: CodeOptionsLanguage<TComponent>
+  variant: CodeBlockVariant
   showLanguageIcon: boolean
   showLanguageName: boolean
   showLineNumbers: boolean
@@ -106,6 +108,9 @@ export interface CodeBlockModel<TComponent = unknown> extends CodeOptionsModel<T
   downloadOptions: SelectOption[]
 }
 
+const CODE_BLOCK_VARIANTS = ['modern', 'classic', 'minimal'] as const
+const DEFAULT_CODE_BLOCK_VARIANT: CodeBlockVariant = 'modern'
+
 export function resolveCodeLanguage(lang?: string | null): string {
   if (!lang)
     return 'plaintext'
@@ -117,12 +122,17 @@ export function createCodeOptionsModel<TComponent = unknown>(
   language: string,
 ): CodeOptionsModel<TComponent> {
   const languageCodeOptions = resolveCodeOptions(codeOptions, language)
+  const configuredVariant = languageCodeOptions.variant
+  const variant = CODE_BLOCK_VARIANTS.includes(configuredVariant as typeof CODE_BLOCK_VARIANTS[number])
+    ? configuredVariant as CodeBlockVariant
+    : DEFAULT_CODE_BLOCK_VARIANT
   const showLanguageIcon = isCodeOptionEnabled(languageCodeOptions.languageIcon)
   const showLanguageName = isCodeOptionEnabled(languageCodeOptions.languageName)
   const showLineNumbers = isCodeOptionEnabled(languageCodeOptions.lineNumbers)
 
   return {
     languageCodeOptions,
+    variant,
     showLanguageIcon,
     showLanguageName,
     showLineNumbers,

--- a/packages/core/src/types/options.ts
+++ b/packages/core/src/types/options.ts
@@ -37,12 +37,15 @@ export interface LinkOptions {
 }
 
 export interface CodeOptions<TComponent = unknown> {
+  variant?: CodeBlockVariant
   languageIcon?: boolean
   languageName?: boolean
   lineNumbers?: boolean
   maxHeight?: number | string
   language?: Record<string, CodeOptionsLanguage<TComponent>>
 }
+
+export type CodeBlockVariant = 'modern' | 'classic' | 'minimal'
 
 export interface CodeOptionsLanguage<TComponent = unknown> extends Omit<CodeOptions<TComponent>, 'languageIcon'> {
   languageIcon?: boolean | TComponent

--- a/packages/vue/__snapshots__/tsnapi/index.snapshot.d.ts
+++ b/packages/vue/__snapshots__/tsnapi/index.snapshot.d.ts
@@ -694,6 +694,7 @@ export { CARETS }
 export { CaretType }
 export { CdnModule }
 export { CdnOptions }
+export { CodeBlockVariant }
 export { ComarkPlugin }
 export { Completion }
 export { CompletionFunction }

--- a/packages/vue/src/components/code-block/index.vue
+++ b/packages/vue/src/components/code-block/index.vue
@@ -167,6 +167,9 @@ const headerControls = computed(
     .filter(item => variant.value !== 'minimal' || item.key !== 'collapse'),
 )
 
+const actionCount = computed(() => headerControls.value.length
+  + (variant.value === 'minimal' && previewable.value ? 1 : 0))
+
 const modalControls = computed(
   () => resolveControls<CodeBlockProps>('code', headerControls.value, props)
     .filter(i => i.key !== 'collapse'),
@@ -240,6 +243,7 @@ async function handleControlClick(key: string, item?: SelectOption) {
     :collapsed="collapsed"
     :loading="!!props.node.loading"
     :max-height="maxHeight"
+    :action-count="actionCount"
     :set-scroll-ref="setScrollRef"
   >
     <template #title>

--- a/packages/vue/src/components/code-block/index.vue
+++ b/packages/vue/src/components/code-block/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { Component } from 'vue'
+import type { Component, VNodeRef } from 'vue'
 import type { CodeBlockProps, Control, SelectOption } from '../../types'
 import {
   createCodeBlockControlDescriptors,
@@ -17,6 +17,10 @@ import Actions from './actions.vue'
 import { LANGUAGE_ICONS } from './language-icons'
 import LanguageTitle from './language-title.vue'
 import PreviewSegmented from './preview-segmented.vue'
+import PreviewToggle from './preview-toggle.vue'
+import ClassicVariant from './variants/classic.vue'
+import MinimalVariant from './variants/minimal.vue'
+import ModernVariant from './variants/modern.vue'
 
 defineOptions({
   inheritAttrs: false,
@@ -74,6 +78,7 @@ const codeBlockModel = computed(() => createCodeBlockModel<Component>({
 }))
 
 const language = computed(() => codeBlockModel.value.language)
+const variant = computed(() => codeBlockModel.value.variant)
 const showLanguageIcon = computed(() => codeBlockModel.value.showLanguageIcon)
 const showLanguageName = computed(() => codeBlockModel.value.showLanguageName)
 const showLanguageTitle = computed(() => codeBlockModel.value.showLanguageTitle)
@@ -113,6 +118,11 @@ const PreviewComponent = computed((): Component | undefined => {
 
 const inlineInteractive = computed(() => codeBlockModel.value.inlineInteractive)
 const maxHeight = computed(() => codeBlockModel.value.maxHeight)
+const VariantComponent = computed(() => ({
+  modern: ModernVariant,
+  classic: ClassicVariant,
+  minimal: MinimalVariant,
+}[variant.value]))
 const downloadOptions = computed(() => codeBlockModel.value.downloadOptions)
 const downloadFilename = computed(() => {
   const type = language.value === 'mermaid' ? 'mermaid' : 'code'
@@ -156,6 +166,10 @@ const modalControls = computed(
 
 const modalLabel = computed(() => t('dialog.fullscreen', 'button.maximize'))
 const modalTitleId = computed(() => showLanguageName.value ? `${props.nodeKey}-fullscreen-title` : undefined)
+
+const setScrollRef: VNodeRef = (element) => {
+  scrollRef.value = element instanceof HTMLElement ? element : undefined
+}
 
 watch(
   () => previewable.value,
@@ -213,26 +227,20 @@ async function handleControlClick(key: string, item?: SelectOption) {
     <div v-else />
   </DefineTemplate>
 
-  <div
-    data-stream-markdown="code-block"
-    dir="ltr"
-    :data-collapsed="collapsed"
-    class="my-4 border border-border rounded-xl overflow-clip data-[collapsed=true]:[&_.code-block-header]:border-b-0"
-    :class="[
-      { 'code-loading': props.node.loading },
-    ]"
+  <component
+    :is="VariantComponent"
+    :collapsed="collapsed"
+    :loading="!!props.node.loading"
+    :max-height="maxHeight"
+    :set-scroll-ref="setScrollRef"
   >
-    <header
-      data-stream-markdown="code-block-header"
-      :class="[
-        { 'border-b': !collapsed },
-      ]"
-      class="code-block-header text-sm text-muted-foreground px-4 py-1.5 border-border bg-muted/80 flex items-center top-0 justify-between sticky z-[5] max-lg:px-3 [&>*:last-child]:flex [&>*:first-child]:flex-1 [&>*:last-child]:flex-1 [&>*:nth-child(2)]:left-1/2 [&>*:last-child]:justify-end [&>*:nth-child(2)]:absolute [&>*:nth-child(2)]:-translate-x-1/2"
-    >
+    <template #title>
       <slot name="title">
         <ReuseTemplate :show-preview="previewPlacement === 'left'" />
       </slot>
+    </template>
 
+    <template #header-center>
       <slot name="header-center">
         <PreviewSegmented
           v-if="previewable && previewPlacement === 'center'"
@@ -241,29 +249,30 @@ async function handleControlClick(key: string, item?: SelectOption) {
         />
         <div v-else />
       </slot>
+    </template>
 
+    <template #actions>
       <slot name="actions">
         <div
           data-stream-markdown="actions"
           class="flex gap-1 items-center"
         >
+          <PreviewToggle
+            v-if="variant === 'minimal' && previewable"
+            v-model:mode="mode"
+            v-model:collapsed="collapsed"
+          />
           <PreviewSegmented
-            v-if="previewable && previewPlacement === 'right'"
+            v-else-if="previewable && previewPlacement === 'right'"
             v-model:mode="mode"
             v-model:collapsed="collapsed"
           />
           <Actions :actions="headerControls" />
         </div>
       </slot>
-    </header>
+    </template>
 
-    <main
-      v-show="!collapsed"
-      ref="scrollRef"
-      data-stream-markdown="code-block-content"
-      class="overflow-auto"
-      :style="{ maxHeight }"
-    >
+    <template #default>
       <component
         :is="PreviewComponent"
         v-if="previewable"
@@ -274,59 +283,59 @@ async function handleControlClick(key: string, item?: SelectOption) {
       <main v-show="mode === 'source'">
         <slot />
       </main>
-    </main>
+    </template>
+  </component>
 
-    <component
-      :is="UI.Modal"
-      v-if="modalMounted"
-      v-model:open="fullscreen"
-      :aria-label="modalLabel"
-      :title-id="modalTitleId"
-      :header-style="{
-        backgroundColor: 'color-mix(in oklab, var(--muted) 80%, transparent)',
-        color: 'var(--muted-foreground)',
-        borderBottom: '1px solid var(--border)',
-      }"
-    >
-      <template #title>
-        <ReuseTemplate :show-preview="previewPlacement === 'left'" />
-      </template>
+  <component
+    :is="UI.Modal"
+    v-if="modalMounted"
+    v-model:open="fullscreen"
+    :aria-label="modalLabel"
+    :title-id="modalTitleId"
+    :header-style="{
+      backgroundColor: 'color-mix(in oklab, var(--muted) 80%, transparent)',
+      color: 'var(--muted-foreground)',
+      borderBottom: '1px solid var(--border)',
+    }"
+  >
+    <template #title>
+      <ReuseTemplate :show-preview="previewPlacement === 'left'" />
+    </template>
 
-      <template #header-center>
+    <template #header-center>
+      <PreviewSegmented
+        v-if="previewable && previewPlacement === 'center'"
+        v-model:mode="mode"
+        v-model:collapsed="collapsed"
+      />
+    </template>
+
+    <template #actions>
+      <div
+        data-stream-markdown="actions"
+        class="flex gap-1 items-center"
+      >
         <PreviewSegmented
-          v-if="previewable && previewPlacement === 'center'"
+          v-if="previewable && previewPlacement === 'right'"
           v-model:mode="mode"
           v-model:collapsed="collapsed"
         />
-      </template>
+        <Actions :actions="modalControls" />
+      </div>
+    </template>
 
-      <template #actions>
-        <div
-          data-stream-markdown="actions"
-          class="flex gap-1 items-center"
-        >
-          <PreviewSegmented
-            v-if="previewable && previewPlacement === 'right'"
-            v-model:mode="mode"
-            v-model:collapsed="collapsed"
-          />
-          <Actions :actions="modalControls" />
-        </div>
-      </template>
-
-      <component
-        :is="PreviewComponent"
-        v-if="previewable"
-        v-show="mode === 'preview'"
-        v-bind="props"
-        :immediate-render="true"
-        container-height="100%"
-      />
-      <CodeNode
-        v-show="mode === 'source'"
-        v-bind="props"
-        :show-header="false"
-      />
-    </component>
-  </div>
+    <component
+      :is="PreviewComponent"
+      v-if="previewable"
+      v-show="mode === 'preview'"
+      v-bind="props"
+      :immediate-render="true"
+      container-height="100%"
+    />
+    <CodeNode
+      v-show="mode === 'source'"
+      v-bind="props"
+      :show-header="false"
+    />
+  </component>
 </template>

--- a/packages/vue/src/components/code-block/index.vue
+++ b/packages/vue/src/components/code-block/index.vue
@@ -119,6 +119,12 @@ const PreviewComponent = computed((): Component | undefined => {
 const inlineInteractive = computed(() => codeBlockModel.value.inlineInteractive)
 const maxHeight = computed(() => codeBlockModel.value.maxHeight)
 const previewVisible = computed(() => previewable.value && mode.value === 'preview')
+const minimalPreviewMinHeight = computed(() => {
+  if (variant.value !== 'minimal' || !previewVisible.value)
+    return undefined
+
+  return 128
+})
 const VariantComponent = computed(() => ({
   modern: ModernVariant,
   classic: ClassicVariant,
@@ -234,7 +240,6 @@ async function handleControlClick(key: string, item?: SelectOption) {
     :collapsed="collapsed"
     :loading="!!props.node.loading"
     :max-height="maxHeight"
-    :preview-visible="previewVisible"
     :set-scroll-ref="setScrollRef"
   >
     <template #title>
@@ -282,6 +287,7 @@ async function handleControlClick(key: string, item?: SelectOption) {
         v-show="mode === 'preview'"
         v-bind="props"
         :interactive="inlineInteractive"
+        :min-height="minimalPreviewMinHeight"
       />
       <main v-show="mode === 'source'">
         <slot />
@@ -334,6 +340,7 @@ async function handleControlClick(key: string, item?: SelectOption) {
       v-bind="props"
       :immediate-render="true"
       container-height="100%"
+      :min-height="minimalPreviewMinHeight"
     />
     <CodeNode
       v-show="mode === 'source'"

--- a/packages/vue/src/components/code-block/index.vue
+++ b/packages/vue/src/components/code-block/index.vue
@@ -83,7 +83,7 @@ const showLanguageIcon = computed(() => codeBlockModel.value.showLanguageIcon)
 const showLanguageName = computed(() => codeBlockModel.value.showLanguageName)
 const showLanguageTitle = computed(() => codeBlockModel.value.showLanguageTitle)
 
-const showCollapse = computed(() => isControlEnabled('code.collapse'))
+const showCollapse = computed(() => variant.value !== 'minimal' && isControlEnabled('code.collapse'))
 const showCopy = computed(() => isControlEnabled('code.copy'))
 const showDownload = computed(() => {
   if (language.value !== 'mermaid')
@@ -156,7 +156,8 @@ const builtinControls = computed((): Control[] => createCodeBlockControlDescript
 })))
 
 const headerControls = computed(
-  () => resolveControls<CodeBlockProps>('code', builtinControls.value, props),
+  () => resolveControls<CodeBlockProps>('code', builtinControls.value, props)
+    .filter(item => variant.value !== 'minimal' || item.key !== 'collapse'),
 )
 
 const modalControls = computed(

--- a/packages/vue/src/components/code-block/index.vue
+++ b/packages/vue/src/components/code-block/index.vue
@@ -118,6 +118,7 @@ const PreviewComponent = computed((): Component | undefined => {
 
 const inlineInteractive = computed(() => codeBlockModel.value.inlineInteractive)
 const maxHeight = computed(() => codeBlockModel.value.maxHeight)
+const previewVisible = computed(() => previewable.value && mode.value === 'preview')
 const VariantComponent = computed(() => ({
   modern: ModernVariant,
   classic: ClassicVariant,
@@ -233,6 +234,7 @@ async function handleControlClick(key: string, item?: SelectOption) {
     :collapsed="collapsed"
     :loading="!!props.node.loading"
     :max-height="maxHeight"
+    :preview-visible="previewVisible"
     :set-scroll-ref="setScrollRef"
   >
     <template #title>

--- a/packages/vue/src/components/code-block/preview-toggle.vue
+++ b/packages/vue/src/components/code-block/preview-toggle.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useContext, useI18n } from '../../composables'
+
+const mode = defineModel<'preview' | 'source'>('mode', { required: true })
+const collapsed = defineModel<boolean>('collapsed', { required: true })
+
+const { icons, uiComponents: UI } = useContext()
+const { t } = useI18n()
+
+const name = computed(() => t(mode.value === 'source' ? 'button.preview' : 'button.source'))
+const icon = computed(() => mode.value === 'source' ? icons.value.preview : icons.value.code)
+
+function toggle() {
+  mode.value = mode.value === 'source' ? 'preview' : 'source'
+  collapsed.value = false
+}
+</script>
+
+<template>
+  <component
+    :is="UI.Button"
+    data-stream-markdown="code-block-preview-toggle"
+    :name="name"
+    :icon="icon"
+    :aria-pressed="mode === 'preview'"
+    @click="toggle"
+  />
+</template>

--- a/packages/vue/src/components/code-block/variants/classic.vue
+++ b/packages/vue/src/components/code-block/variants/classic.vue
@@ -10,7 +10,7 @@ defineProps<CodeBlockVariantProps>()
     data-variant="classic"
     dir="ltr"
     :data-collapsed="collapsed"
-    class="my-4 border border-border rounded-xl overflow-clip data-[collapsed=true]:[&_.code-block-header]:border-b-0"
+    class="my-4 border border-border rounded-xl bg-background overflow-clip data-[collapsed=true]:[&_.code-block-header]:border-b-0"
     :class="[
       { 'code-loading': loading },
     ]"

--- a/packages/vue/src/components/code-block/variants/classic.vue
+++ b/packages/vue/src/components/code-block/variants/classic.vue
@@ -1,0 +1,40 @@
+<script setup lang="ts">
+import type { CodeBlockVariantProps } from './types'
+
+defineProps<CodeBlockVariantProps>()
+</script>
+
+<template>
+  <div
+    data-stream-markdown="code-block"
+    data-variant="classic"
+    dir="ltr"
+    :data-collapsed="collapsed"
+    class="my-4 border border-border rounded-xl overflow-clip data-[collapsed=true]:[&_.code-block-header]:border-b-0"
+    :class="[
+      { 'code-loading': loading },
+    ]"
+  >
+    <header
+      data-stream-markdown="code-block-header"
+      :class="[
+        { 'border-b': !collapsed },
+      ]"
+      class="code-block-header text-sm text-muted-foreground px-4 py-1.5 border-border bg-muted/80 flex items-center top-0 justify-between sticky z-[5] max-lg:px-3 [&>*:last-child]:flex [&>*:first-child]:flex-1 [&>*:last-child]:flex-1 [&>*:nth-child(2)]:left-1/2 [&>*:last-child]:justify-end [&>*:nth-child(2)]:absolute [&>*:nth-child(2)]:-translate-x-1/2"
+    >
+      <slot name="title" />
+      <slot name="header-center" />
+      <slot name="actions" />
+    </header>
+
+    <main
+      v-show="!collapsed"
+      :ref="setScrollRef"
+      data-stream-markdown="code-block-content"
+      class="overflow-auto"
+      :style="{ maxHeight }"
+    >
+      <slot />
+    </main>
+  </div>
+</template>

--- a/packages/vue/src/components/code-block/variants/minimal.vue
+++ b/packages/vue/src/components/code-block/variants/minimal.vue
@@ -28,7 +28,6 @@ defineProps<CodeBlockVariantProps>()
       :ref="setScrollRef"
       data-stream-markdown="code-block-content"
       class="overflow-auto"
-      :class="{ 'min-h-24': previewVisible }"
       :style="{ maxHeight }"
     >
       <slot />

--- a/packages/vue/src/components/code-block/variants/minimal.vue
+++ b/packages/vue/src/components/code-block/variants/minimal.vue
@@ -28,6 +28,7 @@ defineProps<CodeBlockVariantProps>()
       :ref="setScrollRef"
       data-stream-markdown="code-block-content"
       class="overflow-auto"
+      :class="{ 'min-h-24': previewVisible }"
       :style="{ maxHeight }"
     >
       <slot />

--- a/packages/vue/src/components/code-block/variants/minimal.vue
+++ b/packages/vue/src/components/code-block/variants/minimal.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import type { CodeBlockVariantProps } from './types'
+
+defineProps<CodeBlockVariantProps>()
+</script>
+
+<template>
+  <div
+    data-stream-markdown="code-block"
+    data-variant="minimal"
+    dir="ltr"
+    :data-collapsed="collapsed"
+    class="group my-4 border border-border/70 rounded-xl bg-background relative overflow-clip"
+    :class="[
+      { 'code-loading': loading },
+    ]"
+  >
+    <div
+      v-if="$slots.actions"
+      data-stream-markdown="actions"
+      class="flex gap-1.5 items-center right-2 top-2 absolute z-[1]"
+    >
+      <slot name="actions" />
+    </div>
+
+    <main
+      v-show="!collapsed"
+      :ref="setScrollRef"
+      data-stream-markdown="code-block-content"
+      class="overflow-auto"
+      :style="{ maxHeight }"
+    >
+      <slot />
+    </main>
+  </div>
+</template>

--- a/packages/vue/src/components/code-block/variants/minimal.vue
+++ b/packages/vue/src/components/code-block/variants/minimal.vue
@@ -1,7 +1,16 @@
 <script setup lang="ts">
 import type { CodeBlockVariantProps } from './types'
+import { computed } from 'vue'
 
-defineProps<CodeBlockVariantProps>()
+const props = withDefaults(defineProps<CodeBlockVariantProps>(), {
+  actionCount: 0,
+})
+
+const fadeWidth = computed(() => `${99 + Math.max(0, props.actionCount - 1) * 32}px`)
+const contentStyle = computed(() => ({
+  '--code-padding-right': fadeWidth.value,
+  'maxHeight': props.maxHeight,
+}))
 </script>
 
 <template>
@@ -18,7 +27,7 @@ defineProps<CodeBlockVariantProps>()
     <div
       v-if="$slots.actions"
       data-stream-markdown="actions"
-      class="flex gap-1.5 items-center right-2 top-2 absolute z-[1]"
+      class="flex gap-1.5 items-center right-4 top-3 absolute z-[2]"
     >
       <slot name="actions" />
     </div>
@@ -27,10 +36,18 @@ defineProps<CodeBlockVariantProps>()
       v-show="!collapsed"
       :ref="setScrollRef"
       data-stream-markdown="code-block-content"
-      class="overflow-auto"
-      :style="{ maxHeight }"
+      class="overflow-auto [&_pre>code]:pr-[var(--code-padding-right)] [&_pre>code]:block"
+      :style="contentStyle"
     >
       <slot />
     </main>
+
+    <div
+      v-if="$slots.actions"
+      data-stream-markdown="fade-overlay"
+      aria-hidden="true"
+      class="rounded-br-xl rounded-tr-xl bg-[linear-gradient(to_right,transparent_0px,color-mix(in_srgb,var(--background)_20%,transparent)_10px,color-mix(in_srgb,var(--background)_50%,transparent)_25px,color-mix(in_srgb,var(--background)_80%,transparent)_35px,var(--background)_45px)] h-14 pointer-events-none right-0 top-0 absolute z-[1]"
+      :style="{ width: fadeWidth }"
+    />
   </div>
 </template>

--- a/packages/vue/src/components/code-block/variants/modern.vue
+++ b/packages/vue/src/components/code-block/variants/modern.vue
@@ -1,0 +1,40 @@
+<script setup lang="ts">
+import type { CodeBlockVariantProps } from './types'
+
+defineProps<CodeBlockVariantProps>()
+</script>
+
+<template>
+  <div
+    data-stream-markdown="code-block"
+    data-variant="modern"
+    dir="ltr"
+    :data-collapsed="collapsed"
+    class="my-4 p-1 border border-border/70 rounded-xl bg-background overflow-clip data-[collapsed=true]:[&_.code-block-header]:border-b-0"
+    :class="[
+      { 'code-loading': loading },
+    ]"
+  >
+    <header
+      data-stream-markdown="code-block-header"
+      :class="[
+        { 'border-b': !collapsed },
+      ]"
+      class="code-block-header text-sm text-muted-foreground px-3 py-1.5 border-border/70 rounded-lg bg-muted/80 flex items-center top-0 justify-between sticky z-[5] max-lg:px-2 [&>*:last-child]:flex [&>*:first-child]:flex-1 [&>*:last-child]:flex-1 [&>*:nth-child(2)]:left-1/2 [&>*:last-child]:justify-end [&>*:nth-child(2)]:absolute [&>*:nth-child(2)]:-translate-x-1/2"
+    >
+      <slot name="title" />
+      <slot name="header-center" />
+      <slot name="actions" />
+    </header>
+
+    <main
+      v-show="!collapsed"
+      :ref="setScrollRef"
+      data-stream-markdown="code-block-content"
+      class="mt-1 border border-border/70 rounded-lg overflow-auto"
+      :style="{ maxHeight }"
+    >
+      <slot />
+    </main>
+  </div>
+</template>

--- a/packages/vue/src/components/code-block/variants/modern.vue
+++ b/packages/vue/src/components/code-block/variants/modern.vue
@@ -10,17 +10,14 @@ defineProps<CodeBlockVariantProps>()
     data-variant="modern"
     dir="ltr"
     :data-collapsed="collapsed"
-    class="my-4 p-1 border border-border/70 rounded-xl bg-background overflow-clip data-[collapsed=true]:[&_.code-block-header]:border-b-0"
+    class="my-4 p-0.5 border border-border/70 rounded-2xl bg-muted/80 overflow-clip"
     :class="[
       { 'code-loading': loading },
     ]"
   >
     <header
       data-stream-markdown="code-block-header"
-      :class="[
-        { 'border-b': !collapsed },
-      ]"
-      class="code-block-header text-sm text-muted-foreground px-3 py-1.5 border-border/70 rounded-lg bg-muted/80 flex items-center top-0 justify-between sticky z-[5] max-lg:px-2 [&>*:last-child]:flex [&>*:first-child]:flex-1 [&>*:last-child]:flex-1 [&>*:nth-child(2)]:left-1/2 [&>*:last-child]:justify-end [&>*:nth-child(2)]:absolute [&>*:nth-child(2)]:-translate-x-1/2"
+      class="code-block-header text-sm text-muted-foreground px-3 py-1.5 pr-2.5 flex gap-2 items-center top-0 justify-between sticky z-[5] max-lg:px-2 [&>*:last-child]:flex [&>*:first-child]:flex-1 [&>*:last-child]:shrink-0 [&>*:first-child]:min-w-0 [&>*:last-child]:items-center [&>*:nth-child(2)]:left-1/2 [&>*:nth-child(2)]:absolute [&>*:nth-child(2)]:-translate-x-1/2"
     >
       <slot name="title" />
       <slot name="header-center" />
@@ -31,7 +28,7 @@ defineProps<CodeBlockVariantProps>()
       v-show="!collapsed"
       :ref="setScrollRef"
       data-stream-markdown="code-block-content"
-      class="mt-1 border border-border/70 rounded-lg overflow-auto"
+      class="mt-0.5 border border-border/70 rounded-xl bg-background max-w-full min-w-full w-0 overflow-auto"
       :style="{ maxHeight }"
     >
       <slot />

--- a/packages/vue/src/components/code-block/variants/modern.vue
+++ b/packages/vue/src/components/code-block/variants/modern.vue
@@ -10,14 +10,14 @@ defineProps<CodeBlockVariantProps>()
     data-variant="modern"
     dir="ltr"
     :data-collapsed="collapsed"
-    class="my-4 p-0.5 border border-border/70 rounded-2xl bg-muted/80 overflow-clip"
+    class="my-4 p-0.5 border border-border/70 rounded-2xl bg-[color-mix(in_srgb,var(--muted)_80%,var(--background)_20%)] overflow-clip"
     :class="[
       { 'code-loading': loading },
     ]"
   >
     <header
       data-stream-markdown="code-block-header"
-      class="code-block-header text-sm text-muted-foreground px-3 py-1.5 pr-2.5 flex gap-2 items-center top-0 justify-between sticky z-[5] max-lg:px-2 [&>*:last-child]:flex [&>*:first-child]:flex-1 [&>*:last-child]:shrink-0 [&>*:first-child]:min-w-0 [&>*:last-child]:items-center [&>*:nth-child(2)]:left-1/2 [&>*:nth-child(2)]:absolute [&>*:nth-child(2)]:-translate-x-1/2"
+      class="code-block-header text-sm text-muted-foreground px-3 py-1 pr-2.5 bg-[color-mix(in_srgb,var(--muted)_80%,var(--background)_20%)] flex gap-2 items-center top-0 justify-between sticky z-[5] max-lg:px-2 [&>*:last-child]:flex [&>*:first-child]:flex-1 [&>*:last-child]:shrink-0 [&>*:first-child]:min-w-0 [&>*:last-child]:items-center [&>*:nth-child(2)]:left-1/2 [&>*:nth-child(2)]:absolute [&>*:nth-child(2)]:-translate-x-1/2"
     >
       <slot name="title" />
       <slot name="header-center" />

--- a/packages/vue/src/components/code-block/variants/types.ts
+++ b/packages/vue/src/components/code-block/variants/types.ts
@@ -4,5 +4,6 @@ export interface CodeBlockVariantProps {
   collapsed: boolean
   loading: boolean
   maxHeight?: string
+  previewVisible: boolean
   setScrollRef: VNodeRef
 }

--- a/packages/vue/src/components/code-block/variants/types.ts
+++ b/packages/vue/src/components/code-block/variants/types.ts
@@ -4,6 +4,5 @@ export interface CodeBlockVariantProps {
   collapsed: boolean
   loading: boolean
   maxHeight?: string
-  previewVisible: boolean
   setScrollRef: VNodeRef
 }

--- a/packages/vue/src/components/code-block/variants/types.ts
+++ b/packages/vue/src/components/code-block/variants/types.ts
@@ -1,0 +1,8 @@
+import type { VNodeRef } from 'vue'
+
+export interface CodeBlockVariantProps {
+  collapsed: boolean
+  loading: boolean
+  maxHeight?: string
+  setScrollRef: VNodeRef
+}

--- a/packages/vue/src/components/code-block/variants/types.ts
+++ b/packages/vue/src/components/code-block/variants/types.ts
@@ -1,6 +1,7 @@
 import type { VNodeRef } from 'vue'
 
 export interface CodeBlockVariantProps {
+  actionCount?: number
   collapsed: boolean
   loading: boolean
   maxHeight?: string

--- a/packages/vue/src/components/previewers/mermaid.vue
+++ b/packages/vue/src/components/previewers/mermaid.vue
@@ -60,7 +60,9 @@ const error = computed(() => previewState.value.error)
 const loading = computed(() => model.value.loading)
 const showControl = computed(() => model.value.showControl)
 const controlPosition = computed(() => model.value.controlPosition)
-const height = computed(() => model.value.height)
+const height = computed(() => model.value.height === 'auto'
+  ? `${model.value.minHeight}px`
+  : model.value.height)
 
 const { shouldRender } = useDeferredRender({
   targetRef: containerRef,

--- a/packages/vue/src/components/renderers/markdown/index.ts
+++ b/packages/vue/src/components/renderers/markdown/index.ts
@@ -45,6 +45,8 @@ export default defineComponent({
 
     return () => {
       renderedTextKeys = new Set<string>()
+      if (!context.enableAnimate.value)
+        animatedTextKeys.clear()
       textAnimationScheduler.beginPass({
         enabled: context.enableAnimate.value,
         stagger: context.animationStagger.value,

--- a/packages/vue/src/types/shared.ts
+++ b/packages/vue/src/types/shared.ts
@@ -29,6 +29,7 @@ import type { UIButtonProps } from './ui'
 export type {
   BuiltinPreviewers,
   BuiltinUIComponents,
+  CodeBlockVariant,
   CSVSeparator,
   DownloadControlConfig,
   DownloadControlOptions,

--- a/playground/nuxt/app/app.vue
+++ b/playground/nuxt/app/app.vue
@@ -324,7 +324,7 @@ onMounted(() => {
           class="my-4"
           :mode="renderMode"
           :caret="caret"
-          :enable-animate="userConfig.animation !== ''"
+          :enable-animate="!userConfig.staticMode && userConfig.animation !== ''"
           :animation="userConfig.animation"
           :animation-split="userConfig.animationSplit"
           :animation-duration="userConfig.animationDuration"

--- a/playground/nuxt/app/app.vue
+++ b/playground/nuxt/app/app.vue
@@ -100,6 +100,7 @@ const codeOptions = computed((): CodeOptions => {
   }
 
   return {
+    ...options,
     language: {
       mermaid: options,
       html: options,

--- a/playground/nuxt/app/app.vue
+++ b/playground/nuxt/app/app.vue
@@ -94,6 +94,7 @@ const copyContent = computed(() => {
 
 const codeOptions = computed((): CodeOptions => {
   const options: CodeOptions = {
+    variant: userConfig.value.codeBlockVariant,
     languageIcon: !isMobile.value,
     languageName: !isMobile.value,
   }
@@ -283,6 +284,7 @@ onMounted(() => {
         v-model:animation-split="userConfig.animationSplit"
         v-model:animation-duration="userConfig.animationDuration"
         v-model:animation-stagger="userConfig.animationStagger"
+        v-model:code-block-variant="userConfig.codeBlockVariant"
         :content="content"
         :prev-step="prevStep"
         :next-step="nextStep"

--- a/playground/nuxt/app/components/actions.vue
+++ b/playground/nuxt/app/components/actions.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { StreamMarkdownProps } from 'vue-stream-markdown'
+import type { CodeBlockVariant, StreamMarkdownProps } from 'vue-stream-markdown'
 import type { Action } from '../types'
 import { useClipboard } from '@vueuse/core'
 import * as LZString from 'lz-string'
@@ -66,6 +66,7 @@ const animation = defineModel<NonNullable<StreamMarkdownProps['animation']>>('an
 const animationSplit = defineModel<NonNullable<StreamMarkdownProps['animationSplit']>>('animationSplit', { required: false, default: 'auto' })
 const animationDuration = defineModel<number>('animationDuration', { required: false, default: 180 })
 const animationStagger = defineModel<number>('animationStagger', { required: false, default: 40 })
+const codeBlockVariant = defineModel<CodeBlockVariant>('codeBlockVariant', { required: false, default: 'modern' })
 
 function wrapAction(action: Omit<Action, 'key'>): Action | null {
   if (action.visible && !action.visible?.())
@@ -183,6 +184,7 @@ const actions = computed((): Action[] => {
       v-model:animation-split="animationSplit"
       v-model:animation-duration="animationDuration"
       v-model:animation-stagger="animationStagger"
+      v-model:code-block-variant="codeBlockVariant"
       v-model:typing-index="typingIndex"
       v-model:typed-step-min="typedStepMin"
       v-model:typed-step-max="typedStepMax"

--- a/playground/nuxt/app/components/settings-popover.vue
+++ b/playground/nuxt/app/components/settings-popover.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { SelectOption, StreamMarkdownProps } from 'vue-stream-markdown'
+import type { CodeBlockVariant, SelectOption, StreamMarkdownProps } from 'vue-stream-markdown'
 import { THEMES } from 'beautiful-mermaid'
 import { bundledThemesInfo } from 'shiki'
 import { ANIMATION_SPLITS, ANIMATION_TYPES, CARETS } from 'vue-stream-markdown'
@@ -31,6 +31,7 @@ const animation = defineModel<NonNullable<StreamMarkdownProps['animation']>>('an
 const animationSplit = defineModel<NonNullable<StreamMarkdownProps['animationSplit']>>('animationSplit', { required: false, default: 'auto' })
 const animationDuration = defineModel<number>('animationDuration', { required: false, default: 180 })
 const animationStagger = defineModel<number>('animationStagger', { required: false, default: 40 })
+const codeBlockVariant = defineModel<CodeBlockVariant>('codeBlockVariant', { required: false, default: 'modern' })
 
 const animationDurationInput = computed({
   get: () => animationDuration.value,
@@ -141,6 +142,12 @@ const ANIMATION_SPLIT_OPTIONS: SelectOption[] = ANIMATION_SPLITS.map(value => ({
   value,
 }))
 
+const CODE_BLOCK_VARIANT_OPTIONS: SelectOption[] = [
+  { label: 'Modern', value: 'modern' },
+  { label: 'Classic', value: 'classic' },
+  { label: 'Minimal', value: 'minimal' },
+]
+
 function onTypingIndexChange() {
   props.toStep(typingIndex.value)
 }
@@ -218,6 +225,20 @@ watch(() => staticMode.value, () => {
             :class="CONTROL_CLASSES"
             type="number"
             placeholder="Typed delay"
+          />
+        </div>
+
+        <hr :class="DIVIDER_CLASSES">
+        <h3 :class="BLOCK_TITLE_CLASSES">
+          Code Block
+        </h3>
+
+        <div :class="BLOCK_CLASSES">
+          <Label :class="LABEL_CLASSES">Variant</Label>
+          <Select
+            v-model:value="codeBlockVariant"
+            :class="CONTROL_CLASSES"
+            :options="CODE_BLOCK_VARIANT_OPTIONS"
           />
         </div>
 

--- a/playground/nuxt/app/composables/use-user-config.ts
+++ b/playground/nuxt/app/composables/use-user-config.ts
@@ -24,6 +24,7 @@ const DEFAULT_USER_CONFIG: UserConfig = {
   animationSplit: 'auto',
   animationDuration: 180,
   animationStagger: 40,
+  codeBlockVariant: 'modern',
 }
 
 export function useUserConfig() {

--- a/playground/nuxt/app/types.ts
+++ b/playground/nuxt/app/types.ts
@@ -1,7 +1,7 @@
 import type loader from '@monaco-editor/loader'
 import type { BuiltinTheme } from 'shiki'
 import type { Component } from 'vue'
-import type { StreamMarkdownProps } from 'vue-stream-markdown'
+import type { CodeBlockVariant, StreamMarkdownProps } from 'vue-stream-markdown'
 
 export type Monaco = Awaited<ReturnType<typeof loader.init>>
 export type Editor = Awaited<ReturnType<Monaco['editor']['create']>>
@@ -27,6 +27,7 @@ export interface UserConfig {
   animationSplit: NonNullable<StreamMarkdownProps['animationSplit']>
   animationDuration: number
   animationStagger: number
+  codeBlockVariant: CodeBlockVariant
 }
 
 export interface IconButtonProps {

--- a/test/core/models.test.ts
+++ b/test/core/models.test.ts
@@ -64,10 +64,16 @@ describe('core models', () => {
 
     expect(model).toMatchObject({
       language: 'mermaid',
+      variant: 'modern',
       previewable: true,
       previewPlacement: 'center',
       maxHeight: '240px',
     })
+    expect(createCodeBlockModel({
+      node: { lang: 'ts', value: 'const value = 1' },
+      codeOptions: { variant: 'classic' },
+      mode: 'source',
+    }).variant).toBe('classic')
     expect(model.downloadOptions.map(option => option.value)).toEqual(['svg', 'png', 'code'])
     expect(getCodeFileExtension('typescript')).toBe('ts')
     expect(syncCodeBlockMode({ mode: 'source' }, true)).toEqual({ mode: 'preview' })

--- a/test/vue/markdown.test.ts
+++ b/test/vue/markdown.test.ts
@@ -113,6 +113,23 @@ describe('stream markdown', () => {
     wrapper.unmount()
   })
 
+  it('does not render a collapse control for minimal code blocks', async () => {
+    const wrapper = mount(Markdown, {
+      props: {
+        content: '```ts\nconst value = 1\n```',
+        codeOptions: { variant: 'minimal' },
+        controls: { code: { collapse: true } },
+        mode: 'static',
+      },
+    })
+
+    await vi.dynamicImportSettled()
+    await flushPromises()
+
+    expect(wrapper.find('[aria-label="Collapse"]').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
   it('provides every document image to the image renderer', async () => {
     let sources: string[] | undefined
     const Image = markRaw(defineComponent({

--- a/test/vue/markdown.test.ts
+++ b/test/vue/markdown.test.ts
@@ -3,6 +3,7 @@ import type { MarkdownElement } from 'vue-stream-markdown'
 import { flushPromises, mount } from '@vue/test-utils'
 import { describe, expect, it, vi } from 'vitest'
 import { defineComponent, h, markRaw, onMounted, onUnmounted } from 'vue'
+import MinimalVariant from '../../packages/vue/src/components/code-block/variants/minimal.vue'
 import Markdown from '../../packages/vue/src/index.vue'
 
 // These tests exercise Markdown processing, not background UI component loading.
@@ -127,6 +128,20 @@ describe('stream markdown', () => {
     await flushPromises()
 
     expect(wrapper.find('[aria-label="Collapse"]').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('reserves preview space for minimal code blocks', () => {
+    const wrapper = mount(MinimalVariant, {
+      props: {
+        collapsed: false,
+        loading: false,
+        previewVisible: true,
+        setScrollRef: () => {},
+      },
+    })
+
+    expect(wrapper.get('[data-stream-markdown="code-block-content"]').classes()).toContain('min-h-24')
     wrapper.unmount()
   })
 

--- a/test/vue/markdown.test.ts
+++ b/test/vue/markdown.test.ts
@@ -3,6 +3,7 @@ import type { MarkdownElement } from 'vue-stream-markdown'
 import { flushPromises, mount } from '@vue/test-utils'
 import { describe, expect, it, vi } from 'vitest'
 import { defineComponent, h, markRaw, onMounted, onUnmounted } from 'vue'
+import MinimalVariant from '../../packages/vue/src/components/code-block/variants/minimal.vue'
 import Markdown from '../../packages/vue/src/index.vue'
 
 // These tests exercise Markdown processing, not background UI component loading.
@@ -127,6 +128,27 @@ describe('stream markdown', () => {
     await flushPromises()
 
     expect(wrapper.find('[aria-label="Collapse"]').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('keeps minimal code block actions floating over the code', () => {
+    const wrapper = mount(MinimalVariant, {
+      props: {
+        collapsed: false,
+        loading: false,
+        actionCount: 3,
+        setScrollRef: () => {},
+      },
+      slots: {
+        actions: () => h('button', 'Copy'),
+      },
+    })
+
+    const actions = wrapper.get('[data-stream-markdown="actions"]')
+    expect(actions.classes()).toContain('absolute')
+    expect(actions.classes()).toContain('right-4')
+    expect(actions.classes()).not.toContain('shrink-0')
+    expect(wrapper.get('[data-stream-markdown="fade-overlay"]').attributes('style')).toContain('width: 163px')
     wrapper.unmount()
   })
 

--- a/test/vue/markdown.test.ts
+++ b/test/vue/markdown.test.ts
@@ -3,7 +3,6 @@ import type { MarkdownElement } from 'vue-stream-markdown'
 import { flushPromises, mount } from '@vue/test-utils'
 import { describe, expect, it, vi } from 'vitest'
 import { defineComponent, h, markRaw, onMounted, onUnmounted } from 'vue'
-import MinimalVariant from '../../packages/vue/src/components/code-block/variants/minimal.vue'
 import Markdown from '../../packages/vue/src/index.vue'
 
 // These tests exercise Markdown processing, not background UI component loading.
@@ -131,17 +130,28 @@ describe('stream markdown', () => {
     wrapper.unmount()
   })
 
-  it('reserves preview space for minimal code blocks', () => {
-    const wrapper = mount(MinimalVariant, {
+  it('gives minimal Mermaid previews a definite minimum height', async () => {
+    const wrapper = mount(Markdown, {
       props: {
-        collapsed: false,
-        loading: false,
-        previewVisible: true,
-        setScrollRef: () => {},
+        content: '```mermaid\ngraph TD\n```',
+        codeOptions: { variant: 'minimal' },
+        extensions: {
+          mermaid: {
+            preload: async () => {},
+            dispose: () => {},
+            supports: () => true,
+            render: async () => ({ valid: true, svg: '<svg width="100" height="50"></svg>' }),
+          },
+        },
+        mode: 'static',
       },
     })
 
-    expect(wrapper.get('[data-stream-markdown="code-block-content"]').classes()).toContain('min-h-24')
+    await vi.dynamicImportSettled()
+    await flushPromises()
+
+    expect(wrapper.get('[data-stream-markdown="mermaid-previewer"]').attributes('style'))
+      .toContain('height: 128px')
     wrapper.unmount()
   })
 

--- a/test/vue/markdown.test.ts
+++ b/test/vue/markdown.test.ts
@@ -97,6 +97,22 @@ describe('stream markdown', () => {
     wrapper.unmount()
   })
 
+  it.each(['modern', 'classic', 'minimal'] as const)('renders the %s code block variant', async (variant) => {
+    const wrapper = mount(Markdown, {
+      props: {
+        content: '```ts\nconst value = 1\n```',
+        codeOptions: { variant },
+        mode: 'static',
+      },
+    })
+
+    await vi.dynamicImportSettled()
+    await flushPromises()
+
+    expect(wrapper.get('[data-stream-markdown="code-block"]').attributes('data-variant')).toBe(variant)
+    wrapper.unmount()
+  })
+
   it('provides every document image to the image renderer', async () => {
     let sources: string[] | undefined
     const Image = markRaw(defineComponent({

--- a/test/vue/markdown.test.ts
+++ b/test/vue/markdown.test.ts
@@ -16,7 +16,7 @@ interface MarkdownTestVm {
 }
 
 interface MarkdownTestWrapper {
-  setProps: (props: { content?: string, mode?: 'static' | 'streaming' }) => Promise<void>
+  setProps: (props: { content?: string, enableAnimate?: boolean, mode?: 'static' | 'streaming' }) => Promise<void>
 }
 
 describe('stream markdown', () => {
@@ -350,6 +350,27 @@ describe('stream markdown', () => {
 
     wrapper.unmount()
     expect(unmountCount).toBe(1)
+  })
+
+  it('removes streaming text animations when switching to static mode', async () => {
+    const wrapper = mount(Markdown, {
+      props: {
+        animation: 'fade-in',
+        enableAnimate: true,
+        content: 'Animated text',
+        mode: 'streaming',
+      },
+    })
+    const testWrapper = wrapper as unknown as MarkdownTestWrapper
+    await flushPromises()
+
+    expect(wrapper.find('.stream-markdown-text-fade-in').exists()).toBe(true)
+
+    await testWrapper.setProps({ enableAnimate: false, mode: 'static' })
+    await flushPromises()
+
+    expect(wrapper.find('.stream-markdown-text-fade-in').exists()).toBe(false)
+    wrapper.unmount()
   })
 
   it('disables only the loading link and restores it in static mode', async () => {


### PR DESCRIPTION
## Summary
- add classic, modern, and minimal code-block presentation variants
- expose the code-block style option and playground switcher
- keep minimal actions/preview space usable and preserve static-mode behavior

## Verification
- `pnpm exec vitest run test/vue/markdown.test.ts`
- `pnpm -F vue-stream-markdown build:css`