### PR TITLE
fix(extensions): validate CDN module contracts

### DIFF
--- a/packages/extensions/beautiful-mermaid/__snapshots__/tsnapi/index.snapshot.d.ts
+++ b/packages/extensions/beautiful-mermaid/__snapshots__/tsnapi/index.snapshot.d.ts
@@ -5,10 +5,19 @@
 export interface BeautifulMermaidCdnLoaderOptions {
   cdnOptions?: MaybeGetter<SharedCdnOptions | undefined>;
 }
-export interface BeautifulMermaidExtensionOptions<TErrorComponent = never> {
+export interface BeautifulMermaidExtensionOptions<TErrorComponent = never> extends BeautifulMermaidRuntimeOptions {
+  errorComponent?: TErrorComponent;
+}
+export interface BeautifulMermaidRuntime {
+  preload: () => Promise<void>;
+  load: () => Promise<typeof import('beautiful-mermaid')>;
+  dispose: () => void;
+  supports: (_: string) => boolean;
+  render: (_: MermaidRenderInput) => Promise<MermaidExtensionRenderResult>;
+}
+export interface BeautifulMermaidRuntimeOptions {
   cdnOptions?: MaybeGetter<SharedCdnOptions | undefined>;
   config?: MaybeGetter<RenderOptions$1 | undefined>;
-  errorComponent?: TErrorComponent;
   theme?: MaybeGetter<[ThemeName$1, ThemeName$1] | undefined>;
 }
 // #endregion
@@ -19,6 +28,7 @@ export declare function createBeautifulMermaidCdnLoader(_?: BeautifulMermaidCdnL
   getCdnUrl: () => string | undefined;
   loadCdn: () => Promise<typeof import('beautiful-mermaid') | undefined>;
 };
+export declare function createBeautifulMermaidRuntime(_?: BeautifulMermaidRuntimeOptions): BeautifulMermaidRuntime;
 // #endregion
 
 // #region Variables

--- a/packages/extensions/beautiful-mermaid/__snapshots__/tsnapi/index.snapshot.js
+++ b/packages/extensions/beautiful-mermaid/__snapshots__/tsnapi/index.snapshot.js
@@ -4,6 +4,7 @@
 // #region Functions
 export function beautifulMermaid(_) {}
 export function createBeautifulMermaidCdnLoader(_) {}
+export function createBeautifulMermaidRuntime(_) {}
 // #endregion
 
 // #region Variables

--- a/packages/extensions/beautiful-mermaid/src/extension.ts
+++ b/packages/extensions/beautiful-mermaid/src/extension.ts
@@ -11,6 +11,29 @@ import {
   PRESET_BEAUTIFUL_MERMAID_CONFIG,
 } from './constants'
 
+function assertBeautifulMermaidModule(
+  module: unknown,
+  source: string,
+): asserts module is typeof import('beautiful-mermaid') {
+  const candidate = module as Partial<typeof import('beautiful-mermaid')> | null
+  const missing = [
+    typeof candidate?.renderMermaidSVGAsync === 'function' ? undefined : 'renderMermaidSVGAsync',
+    candidate?.THEMES && typeof candidate.THEMES === 'object' ? undefined : 'THEMES',
+    typeof candidate?.fromShikiTheme === 'function' ? undefined : 'fromShikiTheme',
+  ].filter((name): name is string => !!name)
+
+  if (missing.length > 0) {
+    const exports = candidate && typeof candidate === 'object'
+      ? Object.keys(candidate).sort().join(', ') || '(none)'
+      : typeof candidate
+    throw new Error(
+      `[vue-stream-markdown] Invalid Beautiful Mermaid module from ${source}. `
+      + `Missing: ${missing.join(', ')}. `
+      + `Received exports: ${exports}. Expected the full "beautiful-mermaid" entry.`,
+    )
+  }
+}
+
 const DIAGRAM_TYPE_PATTERN = new RegExp(`^(${BEAUTIFUL_MERMAID_SUPPORTED_PATTERNS.join('|')})`)
 
 function extractDiagramType(code: string): string {
@@ -36,6 +59,10 @@ export function beautifulMermaid<TErrorComponent = never>(
 
   async function load() {
     module ??= await cdnLoader.loadCdn() ?? await import('beautiful-mermaid')
+    assertBeautifulMermaidModule(
+      module,
+      cdnLoader.getCdnUrl() ?? 'the local "beautiful-mermaid" package',
+    )
     return module
   }
 

--- a/packages/extensions/beautiful-mermaid/src/extension.ts
+++ b/packages/extensions/beautiful-mermaid/src/extension.ts
@@ -1,114 +1,17 @@
-import type {
-  MermaidExtension,
-  MermaidRenderInput,
-} from '@stream-markdown/core'
+import type { MermaidExtension } from '@stream-markdown/core'
 import type { BeautifulMermaidExtensionOptions } from './types'
-import { resolveGetter } from '@stream-markdown/core'
-import { createBeautifulMermaidCdnLoader } from './cdn'
-import {
-  BEAUTIFUL_MERMAID_SUPPORTED_PATTERNS,
-  DEFAULT_BEAUTIFUL_MERMAID_THEME,
-  PRESET_BEAUTIFUL_MERMAID_CONFIG,
-} from './constants'
-
-function assertBeautifulMermaidModule(
-  module: unknown,
-  source: string,
-): asserts module is typeof import('beautiful-mermaid') {
-  const candidate = module as Partial<typeof import('beautiful-mermaid')> | null
-  const missing = [
-    typeof candidate?.renderMermaidSVGAsync === 'function' ? undefined : 'renderMermaidSVGAsync',
-    candidate?.THEMES && typeof candidate.THEMES === 'object' ? undefined : 'THEMES',
-    typeof candidate?.fromShikiTheme === 'function' ? undefined : 'fromShikiTheme',
-  ].filter((name): name is string => !!name)
-
-  if (missing.length > 0) {
-    const exports = candidate && typeof candidate === 'object'
-      ? Object.keys(candidate).sort().join(', ') || '(none)'
-      : typeof candidate
-    throw new Error(
-      `[vue-stream-markdown] Invalid Beautiful Mermaid module from ${source}. `
-      + `Missing: ${missing.join(', ')}. `
-      + `Received exports: ${exports}. Expected the full "beautiful-mermaid" entry.`,
-    )
-  }
-}
-
-const DIAGRAM_TYPE_PATTERN = new RegExp(`^(${BEAUTIFUL_MERMAID_SUPPORTED_PATTERNS.join('|')})`)
-
-function extractDiagramType(code: string): string {
-  for (const line of code.trim().split('\n')) {
-    const trimmed = line.trim()
-    if (trimmed && !trimmed.startsWith('%%'))
-      return trimmed.match(DIAGRAM_TYPE_PATTERN)?.[1] ?? 'unknown'
-  }
-  return 'unknown'
-}
+import { createBeautifulMermaidRuntime } from './runtime'
 
 export function beautifulMermaid<TErrorComponent = never>(
   options: BeautifulMermaidExtensionOptions<TErrorComponent> = {},
 ): MermaidExtension<TErrorComponent> {
-  let module: typeof import('beautiful-mermaid') | null = null
-  const cdnLoader = createBeautifulMermaidCdnLoader({
-    cdnOptions: options.cdnOptions,
-  })
-
-  const supports = (code: string) => BEAUTIFUL_MERMAID_SUPPORTED_PATTERNS.some(
-    pattern => extractDiagramType(code).startsWith(pattern),
-  )
-
-  async function load() {
-    module ??= await cdnLoader.loadCdn() ?? await import('beautiful-mermaid')
-    assertBeautifulMermaidModule(
-      module,
-      cdnLoader.getCdnUrl() ?? 'the local "beautiful-mermaid" package',
-    )
-    return module
-  }
-
-  async function getRenderOptions(input: MermaidRenderInput) {
-    const renderer = await load()
-    const [light, dark] = resolveGetter(options.theme) ?? DEFAULT_BEAUTIFUL_MERMAID_THEME
-    const preset = renderer.THEMES[input.isDark ? dark : light]
-    const shikiTheme = input.theme
-      ? renderer.fromShikiTheme(input.theme as never)
-      : undefined
-
-    return {
-      ...PRESET_BEAUTIFUL_MERMAID_CONFIG,
-      ...(preset ?? shikiTheme ?? {}),
-      ...(resolveGetter(options.config) ?? {}),
-    }
-  }
+  const runtime = createBeautifulMermaidRuntime(options)
 
   return {
     errorComponent: options.errorComponent,
-    preload: async () => {
-      await load()
-    },
-    dispose() {
-      module = null
-    },
-    supports,
-    async render(input) {
-      if (!supports(input.code))
-        return { supported: false, valid: false }
-
-      try {
-        const renderer = await load()
-        const svg = await renderer.renderMermaidSVGAsync(
-          input.code,
-          await getRenderOptions(input),
-        )
-        return { supported: true, svg, valid: true }
-      }
-      catch (error) {
-        return {
-          supported: true,
-          valid: false,
-          error: error instanceof Error ? error.message : String(error),
-        }
-      }
-    },
+    preload: runtime.preload,
+    dispose: runtime.dispose,
+    supports: runtime.supports,
+    render: runtime.render,
   }
 }

--- a/packages/extensions/beautiful-mermaid/src/index.ts
+++ b/packages/extensions/beautiful-mermaid/src/index.ts
@@ -1,4 +1,5 @@
 export * from './cdn'
 export * from './constants'
 export * from './extension'
+export * from './runtime'
 export * from './types'

--- a/packages/extensions/beautiful-mermaid/src/runtime.ts
+++ b/packages/extensions/beautiful-mermaid/src/runtime.ts
@@ -1,0 +1,119 @@
+import type {
+  MermaidExtensionRenderResult,
+  MermaidRenderInput,
+} from '@stream-markdown/core'
+import type {
+  BeautifulMermaidRuntime,
+  BeautifulMermaidRuntimeOptions,
+} from './types'
+import { resolveGetter } from '@stream-markdown/core'
+import { createBeautifulMermaidCdnLoader } from './cdn'
+import {
+  BEAUTIFUL_MERMAID_SUPPORTED_PATTERNS,
+  DEFAULT_BEAUTIFUL_MERMAID_THEME,
+  PRESET_BEAUTIFUL_MERMAID_CONFIG,
+} from './constants'
+
+function assertBeautifulMermaidModule(
+  module: unknown,
+  source: string,
+): asserts module is typeof import('beautiful-mermaid') {
+  const candidate = module as Partial<typeof import('beautiful-mermaid')> | null
+  const missing = [
+    typeof candidate?.renderMermaidSVGAsync === 'function' ? undefined : 'renderMermaidSVGAsync',
+    candidate?.THEMES && typeof candidate.THEMES === 'object' ? undefined : 'THEMES',
+    typeof candidate?.fromShikiTheme === 'function' ? undefined : 'fromShikiTheme',
+  ].filter((name): name is string => !!name)
+
+  if (missing.length > 0) {
+    const exports = candidate && typeof candidate === 'object'
+      ? Object.keys(candidate).sort().join(', ') || '(none)'
+      : typeof candidate
+    throw new Error(
+      `[vue-stream-markdown] Invalid Beautiful Mermaid module from ${source}. `
+      + `Missing: ${missing.join(', ')}. `
+      + `Received exports: ${exports}. Expected the full "beautiful-mermaid" entry.`,
+    )
+  }
+}
+
+const DIAGRAM_TYPE_PATTERN = new RegExp(`^(${BEAUTIFUL_MERMAID_SUPPORTED_PATTERNS.join('|')})`)
+
+function extractDiagramType(code: string): string {
+  for (const line of code.trim().split('\n')) {
+    const trimmed = line.trim()
+    if (trimmed && !trimmed.startsWith('%%'))
+      return trimmed.match(DIAGRAM_TYPE_PATTERN)?.[1] ?? 'unknown'
+  }
+  return 'unknown'
+}
+
+export function createBeautifulMermaidRuntime(
+  options: BeautifulMermaidRuntimeOptions = {},
+): BeautifulMermaidRuntime {
+  let module: typeof import('beautiful-mermaid') | null = null
+  const cdnLoader = createBeautifulMermaidCdnLoader({
+    cdnOptions: options.cdnOptions,
+  })
+
+  const supports = (code: string) => BEAUTIFUL_MERMAID_SUPPORTED_PATTERNS.some(
+    pattern => extractDiagramType(code).startsWith(pattern),
+  )
+
+  async function load() {
+    module ??= await cdnLoader.loadCdn() ?? await import('beautiful-mermaid')
+    assertBeautifulMermaidModule(
+      module,
+      cdnLoader.getCdnUrl() ?? 'the local "beautiful-mermaid" package',
+    )
+    return module
+  }
+
+  async function getRenderOptions(input: MermaidRenderInput) {
+    const renderer = await load()
+    const [light, dark] = resolveGetter(options.theme) ?? DEFAULT_BEAUTIFUL_MERMAID_THEME
+    const preset = renderer.THEMES[input.isDark ? dark : light]
+    const shikiTheme = input.theme
+      ? renderer.fromShikiTheme(input.theme as never)
+      : undefined
+
+    return {
+      ...PRESET_BEAUTIFUL_MERMAID_CONFIG,
+      ...(preset ?? shikiTheme ?? {}),
+      ...(resolveGetter(options.config) ?? {}),
+    }
+  }
+
+  async function render(input: MermaidRenderInput): Promise<MermaidExtensionRenderResult> {
+    if (!supports(input.code))
+      return { supported: false, valid: false }
+
+    try {
+      const renderer = await load()
+      const svg = await renderer.renderMermaidSVGAsync(
+        input.code,
+        await getRenderOptions(input),
+      )
+      return { supported: true, svg, valid: true }
+    }
+    catch (error) {
+      return {
+        supported: true,
+        valid: false,
+        error: error instanceof Error ? error.message : String(error),
+      }
+    }
+  }
+
+  return {
+    preload: async () => {
+      await load()
+    },
+    load,
+    dispose() {
+      module = null
+    },
+    supports,
+    render,
+  }
+}

--- a/packages/extensions/beautiful-mermaid/src/types.ts
+++ b/packages/extensions/beautiful-mermaid/src/types.ts
@@ -1,11 +1,28 @@
-import type { MaybeGetter, SharedCdnOptions } from '@stream-markdown/core'
+import type {
+  MaybeGetter,
+  MermaidExtensionRenderResult,
+  MermaidRenderInput,
+  SharedCdnOptions,
+} from '@stream-markdown/core'
 import type { RenderOptions, ThemeName } from 'beautiful-mermaid'
 
 export type { RenderOptions, ThemeName } from 'beautiful-mermaid'
 
-export interface BeautifulMermaidExtensionOptions<TErrorComponent = never> {
+export interface BeautifulMermaidRuntimeOptions {
   cdnOptions?: MaybeGetter<SharedCdnOptions | undefined>
   config?: MaybeGetter<RenderOptions | undefined>
-  errorComponent?: TErrorComponent
   theme?: MaybeGetter<[ThemeName, ThemeName] | undefined>
+}
+
+export interface BeautifulMermaidRuntime {
+  preload: () => Promise<void>
+  load: () => Promise<typeof import('beautiful-mermaid')>
+  dispose: () => void
+  supports: (code: string) => boolean
+  render: (input: MermaidRenderInput) => Promise<MermaidExtensionRenderResult>
+}
+
+export interface BeautifulMermaidExtensionOptions<TErrorComponent = never>
+  extends BeautifulMermaidRuntimeOptions {
+  errorComponent?: TErrorComponent
 }

--- a/packages/extensions/cdn-module-guards.test.ts
+++ b/packages/extensions/cdn-module-guards.test.ts
@@ -1,0 +1,76 @@
+import { dynamicImport } from '@stream-markdown/core'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beautifulMermaid } from './beautiful-mermaid/src/extension'
+import { createShikiRuntime } from './code/src/runtime'
+import { createKatexRuntime } from './math/src/runtime'
+import { createMermaidRuntime } from './mermaid/src/runtime'
+
+vi.mock('@stream-markdown/core', async importOriginal => ({
+  ...await importOriginal<typeof import('@stream-markdown/core')>(),
+  dynamicImport: vi.fn(),
+}))
+
+function cdnModule() {
+  return {
+    getUrl: () => 'https://cdn.example.test/module.js',
+  }
+}
+
+describe('cDN module guards', () => {
+  beforeEach(() => {
+    vi.stubGlobal('window', {})
+    vi.stubGlobal('document', { createElement: () => ({}) })
+  })
+
+  afterEach(() => {
+    vi.mocked(dynamicImport).mockReset()
+    vi.unstubAllGlobals()
+  })
+
+  it('reports an incomplete Shiki module', async () => {
+    vi.mocked(dynamicImport).mockResolvedValue({
+      createHighlighter: () => {},
+    })
+    const runtime = createShikiRuntime({
+      cdnOptions: cdnModule(),
+    })
+
+    const error = await runtime.preload().catch(error => error as Error)
+
+    expect(error.message).toMatch(
+      /Invalid Shiki module.*bundledLanguagesInfo.*bundledThemesInfo|Invalid Shiki module.*bundledThemesInfo.*bundledLanguagesInfo/,
+    )
+    expect(error.message).toContain('https://cdn.example.test/module.js')
+  })
+
+  it('reports an incomplete Mermaid module', async () => {
+    vi.mocked(dynamicImport).mockResolvedValue({ default: {} })
+    const runtime = createMermaidRuntime({
+      cdnOptions: cdnModule(),
+    })
+
+    await expect(runtime.load()).rejects.toThrow(
+      /Invalid Mermaid module.*initialize.*parse.*render/,
+    )
+  })
+
+  it('reports an incomplete Beautiful Mermaid module', async () => {
+    vi.mocked(dynamicImport).mockResolvedValue({ renderMermaidSVGAsync: () => {} })
+    const extension = beautifulMermaid({
+      cdnOptions: cdnModule(),
+    })
+
+    await expect(extension.preload()).rejects.toThrow(
+      /Invalid Beautiful Mermaid module.*THEMES.*fromShikiTheme/,
+    )
+  })
+
+  it('reports an incomplete KaTeX module', async () => {
+    vi.mocked(dynamicImport).mockResolvedValue({ render: () => {} })
+    const runtime = createKatexRuntime({
+      cdnOptions: cdnModule(),
+    })
+
+    await expect(runtime.preload()).rejects.toThrow(/Invalid KaTeX module.*renderToString/)
+  })
+})

--- a/packages/extensions/cdn-module-guards.test.ts
+++ b/packages/extensions/cdn-module-guards.test.ts
@@ -35,12 +35,9 @@ describe('cDN module guards', () => {
       cdnOptions: cdnModule(),
     })
 
-    const error = await runtime.preload().catch(error => error as Error)
-
-    expect(error.message).toMatch(
-      /Invalid Shiki module.*bundledLanguagesInfo.*bundledThemesInfo|Invalid Shiki module.*bundledThemesInfo.*bundledLanguagesInfo/,
+    await expect(runtime.preload()).rejects.toThrow(
+      /Invalid Shiki module from https:\/\/cdn\.example\.test\/module\.js.*bundledLanguagesInfo.*bundledThemesInfo|Invalid Shiki module from https:\/\/cdn\.example\.test\/module\.js.*bundledThemesInfo.*bundledLanguagesInfo/,
     )
-    expect(error.message).toContain('https://cdn.example.test/module.js')
   })
 
   it('reports an incomplete Mermaid module', async () => {

--- a/packages/extensions/code/src/runtime.ts
+++ b/packages/extensions/code/src/runtime.ts
@@ -43,6 +43,29 @@ function normalizeShikiModule(module: typeof import('shiki')): typeof import('sh
   return module
 }
 
+function assertShikiModule(
+  module: unknown,
+  source: string,
+): asserts module is typeof import('shiki') {
+  const candidate = module as Partial<typeof import('shiki')> | null
+  const missing = [
+    typeof candidate?.createHighlighter === 'function' ? undefined : 'createHighlighter',
+    Array.isArray(candidate?.bundledThemesInfo) ? undefined : 'bundledThemesInfo',
+    Array.isArray(candidate?.bundledLanguagesInfo) ? undefined : 'bundledLanguagesInfo',
+  ].filter((name): name is string => !!name)
+
+  if (missing.length > 0) {
+    const exports = candidate && typeof candidate === 'object'
+      ? Object.keys(candidate).sort().join(', ') || '(none)'
+      : typeof candidate
+    throw new Error(
+      `[vue-stream-markdown] Invalid Shiki module from ${source}. `
+      + `Missing: ${missing.join(', ')}. `
+      + `Received exports: ${exports}. Expected the full "shiki" entry.`,
+    )
+  }
+}
+
 async function hasBundledShikiModule() {
   try {
     await import('shiki')
@@ -79,7 +102,9 @@ export function createShikiRuntime(options: CodeRuntimeOptions = {}): ShikiRunti
 
   async function getShiki(): Promise<typeof import('shiki')> {
     const module = await cdnLoader.loadCdn() ?? await import('shiki')
-    return normalizeShikiModule(module)
+    const normalized = normalizeShikiModule(module)
+    assertShikiModule(normalized, cdnLoader.getCdnUrl() ?? 'the local "shiki" package')
+    return normalized
   }
 
   async function hasShiki() {

--- a/packages/extensions/math/src/runtime.ts
+++ b/packages/extensions/math/src/runtime.ts
@@ -11,6 +11,27 @@ async function hasBundledKatexModule() {
   }
 }
 
+function assertKatexModule(
+  module: unknown,
+  source: string,
+): asserts module is typeof import('katex') {
+  const candidate = module as Partial<typeof import('katex')> | null
+  const missing = [
+    typeof candidate?.renderToString === 'function' ? undefined : 'renderToString',
+  ].filter((name): name is string => !!name)
+
+  if (missing.length > 0) {
+    const exports = candidate && typeof candidate === 'object'
+      ? Object.keys(candidate).sort().join(', ') || '(none)'
+      : typeof candidate
+    throw new Error(
+      `[vue-stream-markdown] Invalid KaTeX module from ${source}. `
+      + `Missing: ${missing.join(', ')}. `
+      + `Received exports: ${exports}. Expected the KaTeX runtime API.`,
+    )
+  }
+}
+
 export function createKatexRuntime(options: MathRuntimeOptions = {}): KatexRuntime {
   const cdnLoader = createKatexCdnLoader({
     cdnOptions: options.cdnOptions,
@@ -21,7 +42,12 @@ export function createKatexRuntime(options: MathRuntimeOptions = {}): KatexRunti
   }
 
   async function getKatex(): Promise<typeof import('katex')> {
-    return await cdnLoader.loadCdn() ?? await import('katex')
+    const katexImport = await cdnLoader.loadCdn() ?? await import('katex')
+    const katexModule = katexImport.default && typeof katexImport.default === 'object'
+      ? { ...katexImport, ...katexImport.default }
+      : katexImport
+    assertKatexModule(katexModule, cdnLoader.getCdnUrl() ?? 'the local "katex" package')
+    return katexModule
   }
 
   async function renderToHtml(code: string, options?: RenderMathOptions) {

--- a/packages/extensions/mermaid/src/runtime.ts
+++ b/packages/extensions/mermaid/src/runtime.ts
@@ -24,6 +24,29 @@ function toError(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
 }
 
+function assertMermaidModule(
+  module: unknown,
+  source: string,
+): asserts module is Mermaid {
+  const candidate = module as Partial<Mermaid> | null
+  const missing = [
+    typeof candidate?.initialize === 'function' ? undefined : 'initialize',
+    typeof candidate?.parse === 'function' ? undefined : 'parse',
+    typeof candidate?.render === 'function' ? undefined : 'render',
+  ].filter((name): name is string => !!name)
+
+  if (missing.length > 0) {
+    const exports = candidate && typeof candidate === 'object'
+      ? Object.keys(candidate).sort().join(', ') || '(none)'
+      : typeof candidate
+    throw new Error(
+      `[vue-stream-markdown] Invalid Mermaid module from ${source}. `
+      + `Missing: ${missing.join(', ')}. `
+      + `Received exports: ${exports}. Expected the Mermaid runtime API.`,
+    )
+  }
+}
+
 export function createMermaidRuntime(options: MermaidRuntimeOptions = {}): MermaidRuntime {
   let loaded = false
   let mermaid: Mermaid | null = null
@@ -63,7 +86,9 @@ export function createMermaidRuntime(options: MermaidRuntimeOptions = {}): Merma
       throw new Error('Mermaid module is not available')
 
     const mermaidImport = await cdnLoader.loadCdn() ?? await import('mermaid')
-    mermaid = mermaidImport.default
+    const mermaidCandidate = mermaidImport.default ?? mermaidImport
+    assertMermaidModule(mermaidCandidate, cdnLoader.getCdnUrl() ?? 'the local "mermaid" package')
+    mermaid = mermaidCandidate
     mermaid.initialize({
       startOnLoad: false,
       securityLevel: 'loose',


### PR DESCRIPTION
## Summary

- validate the runtime contract of Shiki, Mermaid, Beautiful Mermaid, and KaTeX modules after CDN or local loading
- normalize Mermaid and KaTeX ESM/UMD default export shapes before validation
- report the source URL, missing exports, and received exports when a module is incomplete
- add regression coverage for malformed CDN module responses

## Verification

- `vitest run`: 38 files, 1235 tests passed
- `tsc --noEmit` passed
- package builds passed
- real npm module preload checks passed for all four extensions

Closes #63